### PR TITLE
Add  SSE streaming support (message/stream)

### DIFF
--- a/fasta2a/applications.py
+++ b/fasta2a/applications.py
@@ -1,10 +1,12 @@
 from __future__ import annotations as _annotations
 
+import json
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
 
+from sse_starlette import EventSourceResponse
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
@@ -21,6 +23,8 @@ from .schema import (
     a2a_request_ta,
     a2a_response_ta,
     agent_card_ta,
+    stream_event_ta,
+    stream_message_request_ta,
 )
 from .storage import Storage
 from .task_manager import TaskManager
@@ -41,6 +45,7 @@ class FastA2A(Starlette):
         description: str | None = None,
         provider: AgentProvider | None = None,
         skills: list[Skill] | None = None,
+        streaming: bool = False,
         # Starlette
         debug: bool = False,
         routes: Sequence[Route] | None = None,
@@ -65,6 +70,7 @@ class FastA2A(Starlette):
         self.description = description
         self.provider = provider
         self.skills = skills or []
+        self.streaming = streaming
         # NOTE: For now, I don't think there's any reason to support any other input/output modes.
         self.default_input_modes = ['application/json']
         self.default_output_modes = ['application/json']
@@ -94,7 +100,7 @@ class FastA2A(Starlette):
                 default_input_modes=self.default_input_modes,
                 default_output_modes=self.default_output_modes,
                 capabilities=AgentCapabilities(
-                    streaming=False, push_notifications=False, state_transition_history=False
+                    streaming=self.streaming, push_notifications=False, state_transition_history=False
                 ),
             )
             if self.provider is not None:
@@ -125,6 +131,25 @@ class FastA2A(Starlette):
 
         if a2a_request['method'] == 'message/send':
             jsonrpc_response = await self.task_manager.send_message(a2a_request)
+        elif a2a_request['method'] == 'message/stream':
+            # Parse the streaming request
+            stream_request = stream_message_request_ta.validate_json(data)
+
+            # Create an async generator wrapper that formats events as JSON-RPC responses
+            async def sse_generator():
+                request_id = stream_request.get('id')
+                async for event in self.task_manager.stream_message(stream_request):
+                    # Serialize event to ensure proper camelCase conversion
+                    event_dict = stream_event_ta.dump_python(event, mode='json', by_alias=True)
+
+                    # Wrap in JSON-RPC response
+                    jsonrpc_response = {'jsonrpc': '2.0', 'id': request_id, 'result': event_dict}
+
+                    # Convert to JSON string
+                    yield json.dumps(jsonrpc_response)
+
+            # Return SSE response
+            return EventSourceResponse(sse_generator())
         elif a2a_request['method'] == 'tasks/get':
             jsonrpc_response = await self.task_manager.get_task(a2a_request)
         elif a2a_request['method'] == 'tasks/cancel':

--- a/fasta2a/broker.py
+++ b/fasta2a/broker.py
@@ -4,16 +4,20 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
-from typing import Annotated, Any, Generic, Literal, TypeVar
+from typing import Annotated, Any, Generic, Literal, TypeVar, Union
 
 import anyio
+from anyio.streams.memory import MemoryObjectSendStream
 from opentelemetry.trace import Span, get_current_span, get_tracer
 from pydantic import Discriminator
 from typing_extensions import Self, TypedDict
 
-from .schema import TaskIdParams, TaskSendParams
+from .schema import Message, Task, TaskArtifactUpdateEvent, TaskIdParams, TaskSendParams, TaskStatusUpdateEvent
 
 tracer = get_tracer(__name__)
+
+StreamEvent = Union[Task, Message, TaskStatusUpdateEvent, TaskArtifactUpdateEvent]
+"""Type alias for all events that can be streamed."""
 
 
 @dataclass
@@ -30,12 +34,32 @@ class Broker(ABC):
     @abstractmethod
     async def run_task(self, params: TaskSendParams) -> None:
         """Send a task to be executed by the worker."""
-        raise NotImplementedError('send_run_task is not implemented yet.')
+        ...
 
     @abstractmethod
     async def cancel_task(self, params: TaskIdParams) -> None:
         """Cancel a task."""
-        raise NotImplementedError('send_cancel_task is not implemented yet.')
+        ...
+
+    @abstractmethod
+    async def send_stream_event(self, task_id: str, event: StreamEvent) -> None:
+        """Send a streaming event from worker to subscribers.
+
+        This is used by workers to publish status updates, messages, and artifacts
+        during task execution. Events are forwarded to all active subscribers of
+        the given task_id.
+        """
+        ...
+
+    @abstractmethod
+    def subscribe_to_stream(self, task_id: str) -> AsyncIterator[StreamEvent]:
+        """Subscribe to streaming events for a specific task.
+
+        Returns an async iterator that yields events published by workers for the
+        given task_id. The iterator completes when a TaskStatusUpdateEvent with
+        final=True is received or the subscription is cancelled.
+        """
+        ...
 
     @abstractmethod
     async def __aenter__(self) -> Self: ...
@@ -73,6 +97,10 @@ TaskOperation = Annotated['_RunTask | _CancelTask', Discriminator('operation')]
 class InMemoryBroker(Broker):
     """A broker that schedules tasks in memory."""
 
+    def __init__(self):
+        self._event_subscribers: dict[str, list[MemoryObjectSendStream[StreamEvent]]] = {}
+        self._subscriber_lock: anyio.Lock | None = None
+
     async def __aenter__(self):
         self.aexit_stack = AsyncExitStack()
         await self.aexit_stack.__aenter__()
@@ -80,6 +108,8 @@ class InMemoryBroker(Broker):
         self._write_stream, self._read_stream = anyio.create_memory_object_stream[TaskOperation]()
         await self.aexit_stack.enter_async_context(self._read_stream)
         await self.aexit_stack.enter_async_context(self._write_stream)
+
+        self._subscriber_lock = anyio.Lock()
 
         return self
 
@@ -96,3 +126,65 @@ class InMemoryBroker(Broker):
         """Receive task operations from the broker."""
         async for task_operation in self._read_stream:
             yield task_operation
+
+    async def send_stream_event(self, task_id: str, event: StreamEvent) -> None:
+        """Send a streaming event from worker to subscribers."""
+        assert self._subscriber_lock is not None, 'Broker not initialized'
+
+        async with self._subscriber_lock:
+            subscribers = self._event_subscribers.get(task_id, [])
+            if not subscribers:
+                return
+
+            # Send event to all subscribers, removing closed streams
+            active_subscribers: list[MemoryObjectSendStream[StreamEvent]] = []
+            for stream in subscribers:
+                try:
+                    await stream.send(event)
+                    active_subscribers.append(stream)
+                except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+                    # Subscriber disconnected, remove from list
+                    pass
+
+            # Update subscriber list with only active ones
+            if active_subscribers:
+                self._event_subscribers[task_id] = active_subscribers
+            else:
+                # No active subscribers left, clean up
+                del self._event_subscribers[task_id]
+
+    async def subscribe_to_stream(self, task_id: str) -> AsyncIterator[StreamEvent]:
+        """Subscribe to streaming events for a specific task."""
+        assert self._subscriber_lock is not None, 'Broker not initialized'
+
+        # Create a new stream for this subscriber
+        send_stream, receive_stream = anyio.create_memory_object_stream[StreamEvent](max_buffer_size=100)
+
+        # Register the subscriber
+        async with self._subscriber_lock:
+            if task_id not in self._event_subscribers:
+                self._event_subscribers[task_id] = []
+            self._event_subscribers[task_id].append(send_stream)
+
+        try:
+            async with receive_stream:
+                async for event in receive_stream:
+                    yield event
+
+                    # Check if this is a final status update
+                    if isinstance(event, dict) and event.get('kind') == 'status-update' and event.get('final', False):
+                        break
+        finally:
+            # Clean up subscription on exit
+            async with self._subscriber_lock:
+                if task_id in self._event_subscribers:
+                    try:
+                        self._event_subscribers[task_id].remove(send_stream)
+                        if not self._event_subscribers[task_id]:
+                            del self._event_subscribers[task_id]
+                    except ValueError:
+                        # Already removed
+                        pass
+
+            # Close the send stream
+            await send_stream.aclose()

--- a/fasta2a/schema.py
+++ b/fasta2a/schema.py
@@ -797,3 +797,7 @@ send_message_request_ta: TypeAdapter[SendMessageRequest] = TypeAdapter(SendMessa
 send_message_response_ta: TypeAdapter[SendMessageResponse] = TypeAdapter(SendMessageResponse)
 stream_message_request_ta: TypeAdapter[StreamMessageRequest] = TypeAdapter(StreamMessageRequest)
 stream_message_response_ta: TypeAdapter[StreamMessageResponse] = TypeAdapter(StreamMessageResponse)
+
+# Type adapter for streaming events
+StreamEvent = Union[Task, Message, TaskStatusUpdateEvent, TaskArtifactUpdateEvent]
+stream_event_ta: TypeAdapter[StreamEvent] = TypeAdapter(StreamEvent)

--- a/fasta2a/task_manager.py
+++ b/fasta2a/task_manager.py
@@ -60,12 +60,14 @@ The flow:
 
 from __future__ import annotations as _annotations
 
+import asyncio
 import uuid
+from collections.abc import AsyncGenerator
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from typing import Any
 
-from .broker import Broker
+from .broker import Broker, StreamEvent
 from .schema import (
     CancelTaskRequest,
     CancelTaskResponse,
@@ -79,7 +81,6 @@ from .schema import (
     SetTaskPushNotificationRequest,
     SetTaskPushNotificationResponse,
     StreamMessageRequest,
-    StreamMessageResponse,
     TaskNotFoundError,
     TaskSendParams,
 )
@@ -156,9 +157,40 @@ class TaskManager:
             )
         return CancelTaskResponse(jsonrpc='2.0', id=request['id'], result=task)
 
-    async def stream_message(self, request: StreamMessageRequest) -> StreamMessageResponse:
-        """Stream messages using Server-Sent Events."""
-        raise NotImplementedError('message/stream method is not implemented yet.')
+    async def stream_message(self, request: StreamMessageRequest) -> AsyncGenerator[StreamEvent, None]:
+        """Handle a streaming message request.
+
+        This method:
+        1. Creates and submits a new task
+        2. Yields the initial task object
+        3. Subscribes to the broker's event stream
+        4. Starts task execution asynchronously
+        5. Streams all events until completion
+        """
+        # Extract parameters
+        params = request['params']
+        message = params['message']
+        context_id = message.get('context_id', str(uuid.uuid4()))
+
+        # Create and submit the task
+        task = await self.storage.submit_task(context_id, message)
+
+        # Yield the initial task
+        yield task
+
+        # Prepare broker params
+        broker_params: TaskSendParams = {'id': task['id'], 'context_id': context_id, 'message': message}
+        config = params.get('configuration', {})
+        history_length = config.get('history_length')
+        if history_length is not None:
+            broker_params['history_length'] = history_length
+
+        # Start task execution in background
+        asyncio.create_task(self.broker.run_task(broker_params))
+
+        # Stream events from broker
+        async for event in self.broker.subscribe_to_stream(task['id']):
+            yield event
 
     async def set_task_push_notification(
         self, request: SetTaskPushNotificationRequest

--- a/fasta2a/worker.py
+++ b/fasta2a/worker.py
@@ -14,7 +14,12 @@ from .storage import ContextT, Storage
 
 if TYPE_CHECKING:
     from .broker import Broker, TaskOperation
-    from .schema import Artifact, Message, TaskIdParams, TaskSendParams
+    from .schema import (
+        Artifact,
+        Message,
+        TaskIdParams,
+        TaskSendParams,
+    )
 
 tracer = get_tracer(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "pydantic>=2.10",
     "opentelemetry-api>=1.28.0",
     "eval_type_backport>=0.2.2; python_version <= '3.9'",
+    "sse-starlette>=2.0.0",
 ]
 
 [project.optional-dependencies]
@@ -58,8 +59,10 @@ dev = [
     "asgi-lifespan",
     "coverage",
     "httpx",
+    "httpx-sse",
     "inline-snapshot",
     "pytest",
+    "pytest-asyncio",
     "ruff",
     "pyright",
 ]
@@ -119,4 +122,25 @@ reportMissingModuleSource = false
 include = [
     "fasta2a",
     "tests",
+]
+
+[tool.coverage.run]
+branch = true
+source = ["fasta2a"]
+omit = ["fasta2a/static/*"]
+
+[tool.coverage.report]
+skip_covered = true
+show_missing = true
+precision = 2
+exclude_lines = [
+    # Standard marker for code that's not covered
+    'pragma: no cover',
+    # Don't complain about abstract methods and ellipsis
+    '@abstractmethod',
+    '^\s*\.\.\.\s*$',
+    # Don't complain about TYPE_CHECKING blocks
+    'if TYPE_CHECKING:',
+    # Don't complain about NotImplementedError
+    'raise NotImplementedError',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev = [
     "inline-snapshot",
     "pytest",
     "pytest-asyncio",
+    "pytest-mock",
     "ruff",
     "pyright",
 ]

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -55,8 +55,25 @@ async def test_agent_card_with_all_params():
         url='https://example.com',
         version='2.0.0',
         description='A test agent',
-        provider='Test Provider',
-        skills=['skill1', 'skill2'],
+        provider={'organization': 'Test Provider', 'url': 'https://example.com'},
+        skills=[
+            {
+                'id': 'skill1',
+                'name': 'Skill 1',
+                'description': 'First test skill',
+                'tags': ['test', 'skill1'],
+                'input_modes': ['application/json'],
+                'output_modes': ['application/json'],
+            },
+            {
+                'id': 'skill2',
+                'name': 'Skill 2',
+                'description': 'Second test skill',
+                'tags': ['test', 'skill2'],
+                'input_modes': ['application/json'],
+                'output_modes': ['application/json'],
+            },
+        ],
         streaming=True,
     )
     async with create_test_client(app) as client:
@@ -67,8 +84,10 @@ async def test_agent_card_with_all_params():
         assert data['url'] == 'https://example.com'
         assert data['version'] == '2.0.0'
         assert data['description'] == 'A test agent'
-        assert data['provider'] == 'Test Provider'
-        assert data['skills'] == ['skill1', 'skill2']
+        assert data['provider']['organization'] == 'Test Provider'
+        assert len(data['skills']) == 2
+        assert data['skills'][0]['id'] == 'skill1'
+        assert data['skills'][1]['id'] == 'skill2'
         assert data['capabilities']['streaming'] is True
 
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -44,3 +44,72 @@ async def test_agent_card():
                 },
             }
         )
+
+
+async def test_agent_card_with_all_params():
+    """Test agent card with all parameters specified."""
+    app = FastA2A(
+        storage=InMemoryStorage(),
+        broker=InMemoryBroker(),
+        name='Test Agent',
+        url='https://example.com',
+        version='2.0.0',
+        description='A test agent',
+        provider='Test Provider',
+        skills=['skill1', 'skill2'],
+        streaming=True,
+    )
+    async with create_test_client(app) as client:
+        response = await client.get('/.well-known/agent.json')
+        assert response.status_code == 200
+        data = response.json()
+        assert data['name'] == 'Test Agent'
+        assert data['url'] == 'https://example.com'
+        assert data['version'] == '2.0.0'
+        assert data['description'] == 'A test agent'
+        assert data['provider'] == 'Test Provider'
+        assert data['skills'] == ['skill1', 'skill2']
+        assert data['capabilities']['streaming'] is True
+
+
+async def test_agent_card_head_and_options():
+    """Test HEAD and OPTIONS methods for agent card."""
+    app = FastA2A(storage=InMemoryStorage(), broker=InMemoryBroker())
+    async with create_test_client(app) as client:
+        # Test HEAD
+        head_response = await client.head('/.well-known/agent.json')
+        assert head_response.status_code == 200
+
+        # Test OPTIONS
+        options_response = await client.options('/.well-known/agent.json')
+        assert options_response.status_code == 200
+
+
+async def test_agent_card_caching():
+    """Test that agent card is cached after first generation."""
+    app = FastA2A(storage=InMemoryStorage(), broker=InMemoryBroker(), name='Original')
+    async with create_test_client(app) as client:
+        # First request
+        response1 = await client.get('/.well-known/agent.json')
+        assert response1.status_code == 200
+        data1 = response1.json()
+        assert data1['name'] == 'Original'
+
+        # Modify app (shouldn't affect cached response)
+        app.name = 'Modified'
+
+        # Second request should return cached
+        response2 = await client.get('/.well-known/agent.json')
+        assert response2.status_code == 200
+        data2 = response2.json()
+        assert data2['name'] == 'Original'
+
+
+async def test_docs_endpoint():
+    """Test the /docs endpoint."""
+    app = FastA2A(storage=InMemoryStorage(), broker=InMemoryBroker())
+    async with create_test_client(app) as client:
+        response = await client.get('/docs')
+        assert response.status_code == 200
+        assert response.headers['content-type'] == 'text/html; charset=utf-8'
+        assert b'<!DOCTYPE html>' in response.content or b'<html' in response.content

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,474 @@
+"""Tests for the broker pub/sub functionality."""
+
+import asyncio
+
+import anyio
+import pytest
+
+from fasta2a.broker import InMemoryBroker, StreamEvent
+from fasta2a.schema import Task, TaskArtifactUpdateEvent, TaskStatusUpdateEvent
+
+
+@pytest.mark.asyncio
+async def test_broker_pub_sub_single_subscriber():
+    """Test basic pub/sub with a single subscriber."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-123'
+        events_received = []
+
+        # Create a task to track completion
+        subscriber_done = asyncio.Event()
+
+        async def subscriber():
+            async for event in broker.subscribe_to_stream(task_id):
+                events_received.append(event)
+                # Check for final event
+                if isinstance(event, dict) and event.get('kind') == 'status-update' and event.get('final'):
+                    break
+            subscriber_done.set()
+
+        # Start subscriber in background
+        subscriber_task = asyncio.create_task(subscriber())
+
+        # Give subscriber time to set up
+        await asyncio.sleep(0.1)
+
+        # Send some events
+        test_task: Task = {
+            'id': task_id,
+            'context_id': 'test-context',
+            'kind': 'task',
+            'status': {'state': 'submitted'},
+        }
+        await broker.send_stream_event(task_id, test_task)
+
+        status_update: TaskStatusUpdateEvent = {
+            'kind': 'status-update',
+            'task_id': task_id,
+            'context_id': 'test-context',
+            'status': {'state': 'working'},
+            'final': False,
+        }
+        await broker.send_stream_event(task_id, status_update)
+
+        final_update: TaskStatusUpdateEvent = {
+            'kind': 'status-update',
+            'task_id': task_id,
+            'context_id': 'test-context',
+            'status': {'state': 'completed'},
+            'final': True,
+        }
+        await broker.send_stream_event(task_id, final_update)
+
+        # Wait for subscriber to complete
+        await subscriber_done.wait()
+        await subscriber_task
+
+        # Verify events were received
+        assert len(events_received) == 3
+        assert events_received[0] == test_task
+        assert events_received[1] == status_update
+        assert events_received[2] == final_update
+
+
+@pytest.mark.asyncio
+async def test_broker_pub_sub_multiple_subscribers():
+    """Test pub/sub with multiple subscribers to the same task."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-456'
+        events_sub1 = []
+        events_sub2 = []
+
+        # Create completion events
+        sub1_done = asyncio.Event()
+        sub2_done = asyncio.Event()
+
+        async def subscriber1():
+            async for event in broker.subscribe_to_stream(task_id):
+                events_sub1.append(event)
+                if isinstance(event, dict) and event.get('kind') == 'status-update' and event.get('final'):
+                    break
+            sub1_done.set()
+
+        async def subscriber2():
+            async for event in broker.subscribe_to_stream(task_id):
+                events_sub2.append(event)
+                if isinstance(event, dict) and event.get('kind') == 'status-update' and event.get('final'):
+                    break
+            sub2_done.set()
+
+        # Start both subscribers
+        sub1_task = asyncio.create_task(subscriber1())
+        sub2_task = asyncio.create_task(subscriber2())
+
+        # Give subscribers time to set up
+        await asyncio.sleep(0.1)
+
+        # Send event
+        test_event: TaskStatusUpdateEvent = {
+            'kind': 'status-update',
+            'task_id': task_id,
+            'context_id': 'test-context',
+            'status': {'state': 'completed'},
+            'final': True,
+        }
+        await broker.send_stream_event(task_id, test_event)
+
+        # Wait for both subscribers
+        await sub1_done.wait()
+        await sub2_done.wait()
+        await sub1_task
+        await sub2_task
+
+        # Both should receive the event
+        assert len(events_sub1) == 1
+        assert len(events_sub2) == 1
+        assert events_sub1[0] == test_event
+        assert events_sub2[0] == test_event
+
+
+@pytest.mark.asyncio
+async def test_broker_no_subscribers():
+    """Test sending events when there are no subscribers."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-789'
+
+        # This should not raise an error even with no subscribers
+        test_event: TaskStatusUpdateEvent = {
+            'kind': 'status-update',
+            'task_id': task_id,
+            'context_id': 'test-context',
+            'status': {'state': 'working'},
+            'final': False,
+        }
+        await broker.send_stream_event(task_id, test_event)
+
+        # Verify no subscribers exist
+        assert task_id not in broker._event_subscribers
+
+
+@pytest.mark.asyncio
+async def test_broker_subscriber_cleanup_on_disconnect():
+    """Test that disconnected subscribers are automatically cleaned up."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-cleanup'
+
+        # Create a subscriber that exits early
+        async def early_exit_subscriber():
+            async for event in broker.subscribe_to_stream(task_id):
+                # Exit after first event
+                break
+
+        # Start subscriber
+        subscriber_task = asyncio.create_task(early_exit_subscriber())
+
+        # Give subscriber time to set up
+        await asyncio.sleep(0.1)
+
+        # Verify subscriber is registered
+        assert task_id in broker._event_subscribers
+        assert len(broker._event_subscribers[task_id]) == 1
+
+        # Send first event
+        await broker.send_stream_event(
+            task_id,
+            {
+                'kind': 'status-update',
+                'task_id': task_id,
+                'context_id': 'ctx',
+                'status': {'state': 'working'},
+                'final': False,
+            },
+        )
+
+        # Wait for subscriber to exit
+        await subscriber_task
+
+        # Give time for cleanup to happen
+        await asyncio.sleep(0.1)
+
+        # Add a second subscriber to verify cleanup happens during send
+        events_received = []
+        complete = asyncio.Event()
+
+        async def second_subscriber():
+            async for event in broker.subscribe_to_stream(task_id):
+                events_received.append(event)
+                if isinstance(event, dict) and event.get('final'):
+                    break
+            complete.set()
+
+        sub2_task = asyncio.create_task(second_subscriber())
+        await asyncio.sleep(0.1)
+
+        # Now send another event - the first (disconnected) subscriber should be cleaned up
+        await broker.send_stream_event(
+            task_id,
+            {
+                'kind': 'status-update',
+                'task_id': task_id,
+                'context_id': 'ctx',
+                'status': {'state': 'completed'},
+                'final': True,
+            },
+        )
+
+        # Wait for second subscriber
+        await complete.wait()
+        await sub2_task
+
+        # Verify the second subscriber got the event
+        assert len(events_received) == 1
+        assert events_received[0]['status']['state'] == 'completed'
+
+
+@pytest.mark.asyncio
+async def test_broker_artifact_streaming():
+    """Test streaming artifact update events."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-artifacts'
+        events_received = []
+
+        complete = asyncio.Event()
+
+        async def subscriber():
+            async for event in broker.subscribe_to_stream(task_id):
+                events_received.append(event)
+                if isinstance(event, dict) and event.get('kind') == 'artifact-update' and event.get('last_chunk'):
+                    break
+            complete.set()
+
+        # Start subscriber
+        subscriber_task = asyncio.create_task(subscriber())
+        await asyncio.sleep(0.1)
+
+        # Send artifact updates
+        artifact1: TaskArtifactUpdateEvent = {
+            'kind': 'artifact-update',
+            'task_id': task_id,
+            'context_id': 'test-context',
+            'artifact': {'artifact_id': 'artifact-1', 'parts': [{'kind': 'text', 'text': 'Hello'}]},
+            'append': False,
+        }
+        await broker.send_stream_event(task_id, artifact1)
+
+        artifact2: TaskArtifactUpdateEvent = {
+            'kind': 'artifact-update',
+            'task_id': task_id,
+            'context_id': 'test-context',
+            'artifact': {'artifact_id': 'artifact-1', 'parts': [{'kind': 'text', 'text': ' World'}]},
+            'append': True,
+            'last_chunk': True,
+        }
+        await broker.send_stream_event(task_id, artifact2)
+
+        # Wait for completion
+        await complete.wait()
+        await subscriber_task
+
+        # Verify both artifacts received
+        assert len(events_received) == 2
+        assert events_received[0]['artifact']['parts'][0]['text'] == 'Hello'
+        assert events_received[1]['artifact']['parts'][0]['text'] == ' World'
+        assert events_received[1]['append'] is True
+        assert events_received[1]['last_chunk'] is True
+
+
+@pytest.mark.asyncio
+async def test_broker_concurrent_operations():
+    """Test concurrent pub/sub operations."""
+    async with InMemoryBroker() as broker:
+        num_tasks = 5
+        num_events_per_task = 10
+
+        results = {f'task-{i}': [] for i in range(num_tasks)}
+
+        async def subscriber(task_id: str):
+            async for event in broker.subscribe_to_stream(task_id):
+                results[task_id].append(event)
+                if isinstance(event, dict) and event.get('final'):
+                    break
+
+        async def publisher(task_id: str):
+            for i in range(num_events_per_task - 1):
+                await broker.send_stream_event(
+                    task_id,
+                    {
+                        'kind': 'status-update',
+                        'task_id': task_id,
+                        'context_id': 'ctx',
+                        'status': {'state': 'working'},
+                        'message_num': i,
+                        'final': False,
+                    },
+                )
+                await asyncio.sleep(0.01)  # Small delay to test ordering
+
+            # Send final event
+            await broker.send_stream_event(
+                task_id,
+                {
+                    'kind': 'status-update',
+                    'task_id': task_id,
+                    'context_id': 'ctx',
+                    'status': {'state': 'completed'},
+                    'message_num': num_events_per_task - 1,
+                    'final': True,
+                },
+            )
+
+        # Start all subscribers and publishers concurrently
+        async with anyio.create_task_group() as tg:
+            for i in range(num_tasks):
+                task_id = f'task-{i}'
+                tg.start_soon(subscriber, task_id)
+                tg.start_soon(publisher, task_id)
+
+        # Verify all events were received in order
+        for i in range(num_tasks):
+            task_id = f'task-{i}'
+            assert len(results[task_id]) == num_events_per_task
+            for j in range(num_events_per_task):
+                assert results[task_id][j]['message_num'] == j
+
+
+@pytest.mark.asyncio
+async def test_broker_closed_stream_handling():
+    """Test handling of closed streams when sending events."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-closed'
+
+        # Create a stream and immediately close the receive side
+        send_stream, receive_stream = anyio.create_memory_object_stream[StreamEvent](max_buffer_size=10)
+
+        # Manually add the send stream to subscribers
+        async with broker._subscriber_lock:
+            broker._event_subscribers[task_id] = [send_stream]
+
+        # Close the receive stream to simulate disconnection
+        await receive_stream.aclose()
+
+        # Now try to send an event - should handle the closed stream gracefully
+        test_event: TaskStatusUpdateEvent = {
+            'kind': 'status-update',
+            'task_id': task_id,
+            'context_id': 'test-context',
+            'status': {'state': 'working'},
+            'final': False,
+        }
+
+        # This should not raise an error
+        await broker.send_stream_event(task_id, test_event)
+
+        # Verify the closed stream was removed
+        assert task_id not in broker._event_subscribers
+
+
+@pytest.mark.asyncio
+async def test_broker_early_final_event():
+    """Test that subscription stops on receiving a final event."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-early-final'
+        events_received = []
+
+        async def subscriber():
+            async for event in broker.subscribe_to_stream(task_id):
+                events_received.append(event)
+
+        # Start subscriber
+        subscriber_task = asyncio.create_task(subscriber())
+        await asyncio.sleep(0.1)
+
+        # Send a non-final event
+        await broker.send_stream_event(
+            task_id,
+            {
+                'kind': 'status-update',
+                'task_id': task_id,
+                'context_id': 'ctx',
+                'status': {'state': 'working'},
+                'final': False,
+            },
+        )
+
+        # Send a final event - this should cause the subscriber to exit
+        await broker.send_stream_event(
+            task_id,
+            {
+                'kind': 'status-update',
+                'task_id': task_id,
+                'context_id': 'ctx',
+                'status': {'state': 'completed'},
+                'final': True,
+            },
+        )
+
+        # Wait for subscriber to complete
+        await subscriber_task
+
+        # Send another event after subscriber has exited - no subscribers should receive this
+        await broker.send_stream_event(
+            task_id,
+            {
+                'kind': 'status-update',
+                'task_id': task_id,
+                'context_id': 'ctx',
+                'status': {'state': 'working'},
+                'final': False,
+            },
+        )
+
+        # Should have received only 2 events (not the third)
+        assert len(events_received) == 2
+        assert events_received[1]['final'] is True
+
+
+@pytest.mark.asyncio
+async def test_broker_subscriber_double_removal():
+    """Test edge case of trying to remove a subscriber twice."""
+    async with InMemoryBroker() as broker:
+        task_id = 'test-task-double-remove'
+
+        # Create and manually manage a subscriber
+        send_stream, receive_stream = anyio.create_memory_object_stream[StreamEvent](max_buffer_size=10)
+
+        # Add subscriber
+        async with broker._subscriber_lock:
+            broker._event_subscribers[task_id] = [send_stream]
+
+        # Remove it once
+        async with broker._subscriber_lock:
+            broker._event_subscribers[task_id].remove(send_stream)
+            if not broker._event_subscribers[task_id]:
+                del broker._event_subscribers[task_id]
+
+        # Add it back to test the ValueError path
+        async with broker._subscriber_lock:
+            broker._event_subscribers[task_id] = [send_stream]
+
+        # Now use subscribe_to_stream to create a proper subscription
+        events = []
+
+        async def test_subscriber():
+            async for event in broker.subscribe_to_stream(task_id):
+                events.append(event)
+                # Exit after first event to trigger cleanup
+                break
+
+        # Start subscriber
+        sub_task = asyncio.create_task(test_subscriber())
+        await asyncio.sleep(0.1)
+
+        # Manually remove the send_stream we added (not the one from subscribe_to_stream)
+        async with broker._subscriber_lock:
+            broker._event_subscribers[task_id].remove(send_stream)
+
+        # Send event to trigger the subscriber to exit and cleanup
+        await broker.send_stream_event(task_id, {'kind': 'test', 'data': 'test'})
+
+        # Wait for subscriber
+        await sub_task
+
+        # Clean up
+        await send_stream.aclose()
+        await receive_stream.aclose()

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,12 +1,48 @@
 """Tests for the broker pub/sub functionality."""
 
 import asyncio
+from typing import Any, cast
 
 import anyio
 import pytest
 
 from fasta2a.broker import InMemoryBroker, StreamEvent
-from fasta2a.schema import Task, TaskArtifactUpdateEvent, TaskStatusUpdateEvent
+from fasta2a.schema import Task, TaskArtifactUpdateEvent, TaskState, TaskStatusUpdateEvent
+
+
+def make_status_event(
+    task_id: str, state: TaskState = 'working', final: bool = False, metadata: dict[str, Any] | None = None
+) -> TaskStatusUpdateEvent:
+    """Create a TaskStatusUpdateEvent with common defaults."""
+    event: TaskStatusUpdateEvent = {
+        'kind': 'status-update',
+        'task_id': task_id,
+        'context_id': 'test-context',
+        'status': {'state': state},
+        'final': final,
+    }
+    if metadata:
+        event['metadata'] = metadata
+    return event
+
+
+def make_artifact_event(
+    task_id: str, text: str, append: bool = False, last_chunk: bool = False
+) -> TaskArtifactUpdateEvent:
+    """Create a TaskArtifactUpdateEvent with common defaults."""
+    return {
+        'kind': 'artifact-update',
+        'task_id': task_id,
+        'context_id': 'test-context',
+        'artifact': {'artifact_id': 'artifact-1', 'parts': [{'kind': 'text', 'text': text}]},
+        'append': append,
+        'last_chunk': last_chunk,
+    }
+
+
+def is_final_status_event(event: StreamEvent) -> bool:
+    """Check if event is a final status update."""
+    return isinstance(event, dict) and event.get('kind') == 'status-update' and bool(event.get('final'))
 
 
 @pytest.mark.asyncio
@@ -14,24 +50,27 @@ async def test_broker_pub_sub_single_subscriber():
     """Test basic pub/sub with a single subscriber."""
     async with InMemoryBroker() as broker:
         task_id = 'test-task-123'
-        events_received = []
+        events_received: list[StreamEvent] = []
 
-        # Create a task to track completion
+        # Create events to track subscriber lifecycle
+        subscriber_ready = asyncio.Event()
         subscriber_done = asyncio.Event()
 
         async def subscriber():
+            # Set ready event to signal we're about to start listening
+            subscriber_ready.set()
             async for event in broker.subscribe_to_stream(task_id):
                 events_received.append(event)
                 # Check for final event
-                if isinstance(event, dict) and event.get('kind') == 'status-update' and event.get('final'):
+                if is_final_status_event(event):
                     break
             subscriber_done.set()
 
         # Start subscriber in background
         subscriber_task = asyncio.create_task(subscriber())
 
-        # Give subscriber time to set up
-        await asyncio.sleep(0.1)
+        # Wait for subscriber to be ready
+        await subscriber_ready.wait()
 
         # Send some events
         test_task: Task = {
@@ -42,22 +81,10 @@ async def test_broker_pub_sub_single_subscriber():
         }
         await broker.send_stream_event(task_id, test_task)
 
-        status_update: TaskStatusUpdateEvent = {
-            'kind': 'status-update',
-            'task_id': task_id,
-            'context_id': 'test-context',
-            'status': {'state': 'working'},
-            'final': False,
-        }
+        status_update = make_status_event(task_id, 'working')
         await broker.send_stream_event(task_id, status_update)
 
-        final_update: TaskStatusUpdateEvent = {
-            'kind': 'status-update',
-            'task_id': task_id,
-            'context_id': 'test-context',
-            'status': {'state': 'completed'},
-            'final': True,
-        }
+        final_update = make_status_event(task_id, 'completed', final=True)
         await broker.send_stream_event(task_id, final_update)
 
         # Wait for subscriber to complete
@@ -76,24 +103,28 @@ async def test_broker_pub_sub_multiple_subscribers():
     """Test pub/sub with multiple subscribers to the same task."""
     async with InMemoryBroker() as broker:
         task_id = 'test-task-456'
-        events_sub1 = []
-        events_sub2 = []
+        events_sub1: list[StreamEvent] = []
+        events_sub2: list[StreamEvent] = []
 
-        # Create completion events
+        # Create ready and completion events
+        sub1_ready = asyncio.Event()
+        sub2_ready = asyncio.Event()
         sub1_done = asyncio.Event()
         sub2_done = asyncio.Event()
 
         async def subscriber1():
+            sub1_ready.set()
             async for event in broker.subscribe_to_stream(task_id):
                 events_sub1.append(event)
-                if isinstance(event, dict) and event.get('kind') == 'status-update' and event.get('final'):
+                if is_final_status_event(event):
                     break
             sub1_done.set()
 
         async def subscriber2():
+            sub2_ready.set()
             async for event in broker.subscribe_to_stream(task_id):
                 events_sub2.append(event)
-                if isinstance(event, dict) and event.get('kind') == 'status-update' and event.get('final'):
+                if is_final_status_event(event):
                     break
             sub2_done.set()
 
@@ -101,17 +132,12 @@ async def test_broker_pub_sub_multiple_subscribers():
         sub1_task = asyncio.create_task(subscriber1())
         sub2_task = asyncio.create_task(subscriber2())
 
-        # Give subscribers time to set up
-        await asyncio.sleep(0.1)
+        # Wait for both subscribers to be ready
+        await sub1_ready.wait()
+        await sub2_ready.wait()
 
         # Send event
-        test_event: TaskStatusUpdateEvent = {
-            'kind': 'status-update',
-            'task_id': task_id,
-            'context_id': 'test-context',
-            'status': {'state': 'completed'},
-            'final': True,
-        }
+        test_event = make_status_event(task_id, 'completed', final=True)
         await broker.send_stream_event(task_id, test_event)
 
         # Wait for both subscribers
@@ -134,64 +160,52 @@ async def test_broker_no_subscribers():
         task_id = 'test-task-789'
 
         # This should not raise an error even with no subscribers
-        test_event: TaskStatusUpdateEvent = {
-            'kind': 'status-update',
-            'task_id': task_id,
-            'context_id': 'test-context',
-            'status': {'state': 'working'},
-            'final': False,
-        }
+        test_event = make_status_event(task_id, 'working')
         await broker.send_stream_event(task_id, test_event)
 
-        # Verify no subscribers exist
-        assert task_id not in broker._event_subscribers
+        # Test passes if no error is raised when sending with no subscribers
 
 
 @pytest.mark.asyncio
 async def test_broker_subscriber_cleanup_on_disconnect():
-    """Test that disconnected subscribers are automatically cleaned up."""
+    """Test that broker continues to work correctly after subscribers disconnect."""
     async with InMemoryBroker() as broker:
         task_id = 'test-task-cleanup'
+        first_subscriber_events: list[StreamEvent] = []
+
+        # Create ready event for first subscriber
+        first_subscriber_ready = asyncio.Event()
 
         # Create a subscriber that exits early
         async def early_exit_subscriber():
+            first_subscriber_ready.set()
             async for event in broker.subscribe_to_stream(task_id):
+                first_subscriber_events.append(event)
                 # Exit after first event
                 break
 
         # Start subscriber
         subscriber_task = asyncio.create_task(early_exit_subscriber())
 
-        # Give subscriber time to set up
-        await asyncio.sleep(0.1)
-
-        # Verify subscriber is registered
-        assert task_id in broker._event_subscribers
-        assert len(broker._event_subscribers[task_id]) == 1
+        # Wait for subscriber to be ready
+        await first_subscriber_ready.wait()
 
         # Send first event
-        await broker.send_stream_event(
-            task_id,
-            {
-                'kind': 'status-update',
-                'task_id': task_id,
-                'context_id': 'ctx',
-                'status': {'state': 'working'},
-                'final': False,
-            },
-        )
+        await broker.send_stream_event(task_id, make_status_event(task_id, 'working'))
 
         # Wait for subscriber to exit
         await subscriber_task
 
-        # Give time for cleanup to happen
-        await asyncio.sleep(0.1)
+        # Verify first subscriber received the event before disconnecting
+        assert len(first_subscriber_events) == 1
 
-        # Add a second subscriber to verify cleanup happens during send
-        events_received = []
+        # Add a second subscriber to verify system continues working
+        events_received: list[StreamEvent] = []
+        second_subscriber_ready = asyncio.Event()
         complete = asyncio.Event()
 
         async def second_subscriber():
+            second_subscriber_ready.set()
             async for event in broker.subscribe_to_stream(task_id):
                 events_received.append(event)
                 if isinstance(event, dict) and event.get('final'):
@@ -199,27 +213,22 @@ async def test_broker_subscriber_cleanup_on_disconnect():
             complete.set()
 
         sub2_task = asyncio.create_task(second_subscriber())
-        await asyncio.sleep(0.1)
+        await second_subscriber_ready.wait()
 
-        # Now send another event - the first (disconnected) subscriber should be cleaned up
-        await broker.send_stream_event(
-            task_id,
-            {
-                'kind': 'status-update',
-                'task_id': task_id,
-                'context_id': 'ctx',
-                'status': {'state': 'completed'},
-                'final': True,
-            },
-        )
+        # Send another event - verifies broker works after first subscriber disconnected
+        await broker.send_stream_event(task_id, make_status_event(task_id, 'completed', final=True))
 
         # Wait for second subscriber
         await complete.wait()
         await sub2_task
 
-        # Verify the second subscriber got the event
+        # Verify the second subscriber got only the new event (not the old one)
         assert len(events_received) == 1
-        assert events_received[0]['status']['state'] == 'completed'
+        event = events_received[0]
+        assert isinstance(event, dict) and event.get('kind') == 'status-update'
+        # Type narrow to TaskStatusUpdateEvent
+        status_event = cast(TaskStatusUpdateEvent, event)
+        assert status_event['status']['state'] == 'completed'
 
 
 @pytest.mark.asyncio
@@ -227,11 +236,13 @@ async def test_broker_artifact_streaming():
     """Test streaming artifact update events."""
     async with InMemoryBroker() as broker:
         task_id = 'test-task-artifacts'
-        events_received = []
+        events_received: list[StreamEvent] = []
 
+        subscriber_ready = asyncio.Event()
         complete = asyncio.Event()
 
         async def subscriber():
+            subscriber_ready.set()
             async for event in broker.subscribe_to_stream(task_id):
                 events_received.append(event)
                 if isinstance(event, dict) and event.get('kind') == 'artifact-update' and event.get('last_chunk'):
@@ -240,26 +251,13 @@ async def test_broker_artifact_streaming():
 
         # Start subscriber
         subscriber_task = asyncio.create_task(subscriber())
-        await asyncio.sleep(0.1)
+        await subscriber_ready.wait()
 
         # Send artifact updates
-        artifact1: TaskArtifactUpdateEvent = {
-            'kind': 'artifact-update',
-            'task_id': task_id,
-            'context_id': 'test-context',
-            'artifact': {'artifact_id': 'artifact-1', 'parts': [{'kind': 'text', 'text': 'Hello'}]},
-            'append': False,
-        }
+        artifact1 = make_artifact_event(task_id, 'Hello')
         await broker.send_stream_event(task_id, artifact1)
 
-        artifact2: TaskArtifactUpdateEvent = {
-            'kind': 'artifact-update',
-            'task_id': task_id,
-            'context_id': 'test-context',
-            'artifact': {'artifact_id': 'artifact-1', 'parts': [{'kind': 'text', 'text': ' World'}]},
-            'append': True,
-            'last_chunk': True,
-        }
+        artifact2 = make_artifact_event(task_id, ' World', append=True, last_chunk=True)
         await broker.send_stream_event(task_id, artifact2)
 
         # Wait for completion
@@ -268,10 +266,28 @@ async def test_broker_artifact_streaming():
 
         # Verify both artifacts received
         assert len(events_received) == 2
-        assert events_received[0]['artifact']['parts'][0]['text'] == 'Hello'
-        assert events_received[1]['artifact']['parts'][0]['text'] == ' World'
-        assert events_received[1]['append'] is True
-        assert events_received[1]['last_chunk'] is True
+
+        # Check first artifact
+        event0 = events_received[0]
+        assert isinstance(event0, dict) and event0.get('kind') == 'artifact-update'
+        # Type narrow to TaskArtifactUpdateEvent
+        artifact_event0 = cast(TaskArtifactUpdateEvent, event0)
+        artifact_parts = artifact_event0['artifact']['parts']
+        assert len(artifact_parts) > 0
+        part = artifact_parts[0]
+        assert part['kind'] == 'text' and 'text' in part and part['text'] == 'Hello'
+
+        # Check second artifact
+        event1 = events_received[1]
+        assert isinstance(event1, dict) and event1.get('kind') == 'artifact-update'
+        # Type narrow to TaskArtifactUpdateEvent
+        artifact_event1 = cast(TaskArtifactUpdateEvent, event1)
+        artifact_parts = artifact_event1['artifact']['parts']
+        assert len(artifact_parts) > 0
+        part = artifact_parts[0]
+        assert part['kind'] == 'text' and 'text' in part and part['text'] == ' World'
+        assert artifact_event1.get('append') is True
+        assert artifact_event1.get('last_chunk') is True
 
 
 @pytest.mark.asyncio
@@ -281,7 +297,7 @@ async def test_broker_concurrent_operations():
         num_tasks = 5
         num_events_per_task = 10
 
-        results = {f'task-{i}': [] for i in range(num_tasks)}
+        results: dict[str, list[StreamEvent]] = {f'task-{i}': [] for i in range(num_tasks)}
 
         async def subscriber(task_id: str):
             async for event in broker.subscribe_to_stream(task_id):
@@ -291,31 +307,14 @@ async def test_broker_concurrent_operations():
 
         async def publisher(task_id: str):
             for i in range(num_events_per_task - 1):
-                await broker.send_stream_event(
-                    task_id,
-                    {
-                        'kind': 'status-update',
-                        'task_id': task_id,
-                        'context_id': 'ctx',
-                        'status': {'state': 'working'},
-                        'message_num': i,
-                        'final': False,
-                    },
-                )
-                await asyncio.sleep(0.01)  # Small delay to test ordering
+                event = make_status_event(task_id, 'working', metadata={'message_num': i})
+                await broker.send_stream_event(task_id, event)
 
             # Send final event
-            await broker.send_stream_event(
-                task_id,
-                {
-                    'kind': 'status-update',
-                    'task_id': task_id,
-                    'context_id': 'ctx',
-                    'status': {'state': 'completed'},
-                    'message_num': num_events_per_task - 1,
-                    'final': True,
-                },
+            final_event = make_status_event(
+                task_id, 'completed', final=True, metadata={'message_num': num_events_per_task - 1}
             )
+            await broker.send_stream_event(task_id, final_event)
 
         # Start all subscribers and publishers concurrently
         async with anyio.create_task_group() as tg:
@@ -329,39 +328,9 @@ async def test_broker_concurrent_operations():
             task_id = f'task-{i}'
             assert len(results[task_id]) == num_events_per_task
             for j in range(num_events_per_task):
-                assert results[task_id][j]['message_num'] == j
-
-
-@pytest.mark.asyncio
-async def test_broker_closed_stream_handling():
-    """Test handling of closed streams when sending events."""
-    async with InMemoryBroker() as broker:
-        task_id = 'test-task-closed'
-
-        # Create a stream and immediately close the receive side
-        send_stream, receive_stream = anyio.create_memory_object_stream[StreamEvent](max_buffer_size=10)
-
-        # Manually add the send stream to subscribers
-        async with broker._subscriber_lock:
-            broker._event_subscribers[task_id] = [send_stream]
-
-        # Close the receive stream to simulate disconnection
-        await receive_stream.aclose()
-
-        # Now try to send an event - should handle the closed stream gracefully
-        test_event: TaskStatusUpdateEvent = {
-            'kind': 'status-update',
-            'task_id': task_id,
-            'context_id': 'test-context',
-            'status': {'state': 'working'},
-            'final': False,
-        }
-
-        # This should not raise an error
-        await broker.send_stream_event(task_id, test_event)
-
-        # Verify the closed stream was removed
-        assert task_id not in broker._event_subscribers
+                event = results[task_id][j]
+                assert isinstance(event, dict) and 'metadata' in event
+                assert event['metadata']['message_num'] == j
 
 
 @pytest.mark.asyncio
@@ -369,106 +338,35 @@ async def test_broker_early_final_event():
     """Test that subscription stops on receiving a final event."""
     async with InMemoryBroker() as broker:
         task_id = 'test-task-early-final'
-        events_received = []
+        events_received: list[StreamEvent] = []
+
+        subscriber_ready = asyncio.Event()
 
         async def subscriber():
+            subscriber_ready.set()
             async for event in broker.subscribe_to_stream(task_id):
                 events_received.append(event)
 
         # Start subscriber
         subscriber_task = asyncio.create_task(subscriber())
-        await asyncio.sleep(0.1)
+        await subscriber_ready.wait()
 
         # Send a non-final event
-        await broker.send_stream_event(
-            task_id,
-            {
-                'kind': 'status-update',
-                'task_id': task_id,
-                'context_id': 'ctx',
-                'status': {'state': 'working'},
-                'final': False,
-            },
-        )
+        await broker.send_stream_event(task_id, make_status_event(task_id, 'working'))
 
         # Send a final event - this should cause the subscriber to exit
-        await broker.send_stream_event(
-            task_id,
-            {
-                'kind': 'status-update',
-                'task_id': task_id,
-                'context_id': 'ctx',
-                'status': {'state': 'completed'},
-                'final': True,
-            },
-        )
+        await broker.send_stream_event(task_id, make_status_event(task_id, 'completed', final=True))
 
         # Wait for subscriber to complete
         await subscriber_task
 
         # Send another event after subscriber has exited - no subscribers should receive this
-        await broker.send_stream_event(
-            task_id,
-            {
-                'kind': 'status-update',
-                'task_id': task_id,
-                'context_id': 'ctx',
-                'status': {'state': 'working'},
-                'final': False,
-            },
-        )
+        await broker.send_stream_event(task_id, make_status_event(task_id, 'working'))
 
         # Should have received only 2 events (not the third)
         assert len(events_received) == 2
-        assert events_received[1]['final'] is True
-
-
-@pytest.mark.asyncio
-async def test_broker_subscriber_double_removal():
-    """Test edge case of trying to remove a subscriber twice."""
-    async with InMemoryBroker() as broker:
-        task_id = 'test-task-double-remove'
-
-        # Create and manually manage a subscriber
-        send_stream, receive_stream = anyio.create_memory_object_stream[StreamEvent](max_buffer_size=10)
-
-        # Add subscriber
-        async with broker._subscriber_lock:
-            broker._event_subscribers[task_id] = [send_stream]
-
-        # Remove it once
-        async with broker._subscriber_lock:
-            broker._event_subscribers[task_id].remove(send_stream)
-            if not broker._event_subscribers[task_id]:
-                del broker._event_subscribers[task_id]
-
-        # Add it back to test the ValueError path
-        async with broker._subscriber_lock:
-            broker._event_subscribers[task_id] = [send_stream]
-
-        # Now use subscribe_to_stream to create a proper subscription
-        events = []
-
-        async def test_subscriber():
-            async for event in broker.subscribe_to_stream(task_id):
-                events.append(event)
-                # Exit after first event to trigger cleanup
-                break
-
-        # Start subscriber
-        sub_task = asyncio.create_task(test_subscriber())
-        await asyncio.sleep(0.1)
-
-        # Manually remove the send_stream we added (not the one from subscribe_to_stream)
-        async with broker._subscriber_lock:
-            broker._event_subscribers[task_id].remove(send_stream)
-
-        # Send event to trigger the subscriber to exit and cleanup
-        await broker.send_stream_event(task_id, {'kind': 'test', 'data': 'test'})
-
-        # Wait for subscriber
-        await sub_task
-
-        # Clean up
-        await send_stream.aclose()
-        await receive_stream.aclose()
+        # Check the second event is final
+        event = events_received[1]
+        assert isinstance(event, dict) and event.get('kind') == 'status-update'
+        status_event = cast(TaskStatusUpdateEvent, event)
+        assert status_event['final'] is True

--- a/tests/test_streaming_integration.py
+++ b/tests/test_streaming_integration.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -17,6 +17,81 @@ from fasta2a import FastA2A, Worker
 from fasta2a.broker import InMemoryBroker
 from fasta2a.schema import Artifact, Message, TaskIdParams, TaskSendParams
 from fasta2a.storage import InMemoryStorage
+
+
+def make_stream_request(
+    text: str, request_id: str | int | None = 'test-req', message_id: str = 'test-msg'
+) -> dict[str, Any]:
+    """Create a JSON-RPC streaming request with defaults."""
+    return {
+        'jsonrpc': '2.0',
+        'id': request_id,
+        'method': 'message/stream',
+        'params': {
+            'message': {
+                'role': 'user',
+                'parts': [{'kind': 'text', 'text': text}],
+                'messageId': message_id,
+                'kind': 'message',
+            }
+        },
+    }
+
+
+def make_send_request(
+    text: str, request_id: str | int | None = 'test-req', message_id: str = 'test-msg'
+) -> dict[str, Any]:
+    """Create a JSON-RPC send request with defaults."""
+    return {
+        'jsonrpc': '2.0',
+        'id': request_id,
+        'method': 'message/send',
+        'params': {
+            'message': {
+                'role': 'user',
+                'parts': [{'kind': 'text', 'text': text}],
+                'messageId': message_id,
+                'kind': 'message',
+            }
+        },
+    }
+
+
+def make_get_task_request(task_id: str, request_id: str | int | None = 'test-req') -> dict[str, Any]:
+    """Create a JSON-RPC get task request with defaults."""
+    return {'jsonrpc': '2.0', 'id': request_id, 'method': 'tasks/get', 'params': {'id': task_id}}
+
+
+async def collect_sse_events(
+    client: httpx.AsyncClient,
+    request_data: dict[str, Any],
+    stop_condition: Callable[[dict[str, Any]], bool] | None = None,
+) -> list[dict[str, Any]]:
+    """Collect all SSE events from a streaming request."""
+    events: list[dict[str, Any]] = []
+    async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
+        async for sse in event_source.aiter_sse():
+            event_data = json.loads(sse.data)
+            events.append(event_data)
+            if stop_condition and stop_condition(event_data):
+                break
+    return events
+
+
+def get_status_updates(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract status update events."""
+    return [e for e in events if e.get('result', {}).get('kind') == 'status-update']
+
+
+def get_artifact_updates(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract artifact update events."""
+    return [e for e in events if e.get('result', {}).get('kind') == 'artifact-update']
+
+
+def get_tasks(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract task events."""
+    return [e for e in events if e.get('result', {}).get('kind') == 'task']
+
 
 Context = list[Message]
 """The shape of the context you store in the storage."""
@@ -76,9 +151,6 @@ class StreamingWorker(Worker[Context]):
                 },
             )
 
-            # Small delay to simulate processing
-            await asyncio.sleep(0.05)
-
         # Store the complete artifact
         complete_artifact: Artifact = {
             'artifact_id': 'result-1',
@@ -111,7 +183,7 @@ class StreamingWorker(Worker[Context]):
 
 
 @pytest_asyncio.fixture(scope='function')
-async def streaming_app():
+async def streaming_app() -> FastA2A:
     """Create a FastA2A app with streaming enabled and a streaming worker."""
     storage = InMemoryStorage()
     broker = InMemoryBroker()
@@ -137,35 +209,15 @@ async def streaming_app():
 
 
 @pytest.mark.asyncio
-async def test_streaming_endpoint_basic(streaming_app):
+async def test_streaming_endpoint_basic(streaming_app: FastA2A) -> None:
     """Test basic streaming functionality."""
     async with LifespanManager(streaming_app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
         ) as client:
             # Send a streaming request
-            request_data = {
-                'jsonrpc': '2.0',
-                'id': 'test-1',
-                'method': 'message/stream',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Test streaming'}],
-                        'messageId': 'msg-1',
-                        'kind': 'message',
-                    }
-                },
-            }
-
-            events_received = []
-
-            # Make streaming request using httpx-sse
-            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
-                # Collect all events
-                async for sse in event_source.aiter_sse():
-                    event_data = json.loads(sse.data)
-                    events_received.append(event_data)
+            request_data = make_stream_request('Test streaming', 'test-1', 'msg-1')
+            events_received = await collect_sse_events(client, request_data)
 
             # Verify we received events
             assert len(events_received) > 0
@@ -179,17 +231,15 @@ async def test_streaming_endpoint_basic(streaming_app):
             assert first_event['result']['status']['state'] == 'submitted'
 
             # Should have status updates
-            status_updates = [e for e in events_received if e.get('result', {}).get('kind') == 'status-update']
+            status_updates = get_status_updates(events_received)
             assert len(status_updates) >= 2  # At least working and completed
 
             # Should have artifact updates
-            artifact_updates = [e for e in events_received if e.get('result', {}).get('kind') == 'artifact-update']
+            artifact_updates = get_artifact_updates(events_received)
             assert len(artifact_updates) == 4  # 4 parts
 
             # Last status update should be final
-            last_status = next(
-                e for e in reversed(events_received) if e.get('result', {}).get('kind') == 'status-update'
-            )
+            last_status = status_updates[-1]
             assert last_status['result']['status']['state'] == 'completed'
             assert last_status['result']['final'] is True
 
@@ -198,33 +248,15 @@ async def test_streaming_endpoint_basic(streaming_app):
 
 
 @pytest.mark.asyncio
-async def test_streaming_endpoint_incremental_artifacts(streaming_app):
+async def test_streaming_endpoint_incremental_artifacts(streaming_app: FastA2A) -> None:
     """Test that artifacts are streamed incrementally."""
     async with LifespanManager(streaming_app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
         ) as client:
-            request_data = {
-                'jsonrpc': '2.0',
-                'id': 'test-2',
-                'method': 'message/stream',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Test artifacts'}],
-                        'messageId': 'msg-2',
-                        'kind': 'message',
-                    }
-                },
-            }
-
-            artifact_events = []
-
-            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
-                async for sse in event_source.aiter_sse():
-                    event_data = json.loads(sse.data)
-                    if event_data.get('result', {}).get('kind') == 'artifact-update':
-                        artifact_events.append(event_data['result'])
+            request_data = make_stream_request('Test artifacts', 'test-2', 'msg-2')
+            events = await collect_sse_events(client, request_data)
+            artifact_events = [e['result'] for e in get_artifact_updates(events)]
 
             # Verify artifact streaming
             assert len(artifact_events) == 4
@@ -250,26 +282,14 @@ async def test_streaming_endpoint_incremental_artifacts(streaming_app):
 
 
 @pytest.mark.asyncio
-async def test_streaming_vs_non_streaming_endpoints(streaming_app):
+async def test_streaming_vs_non_streaming_endpoints(streaming_app: FastA2A) -> None:
     """Test that both streaming and non-streaming endpoints work."""
     async with LifespanManager(streaming_app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
         ) as client:
             # First, test non-streaming endpoint
-            non_streaming_request = {
-                'jsonrpc': '2.0',
-                'id': 'test-3',
-                'method': 'message/send',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Non-streaming test'}],
-                        'messageId': 'msg-3',
-                        'kind': 'message',
-                    }
-                },
-            }
+            non_streaming_request = make_send_request('Non-streaming test', 'test-3', 'msg-3')
 
             # Non-streaming should return immediately with task
             response = await client.post('/', json=non_streaming_request)
@@ -279,16 +299,20 @@ async def test_streaming_vs_non_streaming_endpoints(streaming_app):
             assert data['result']['status']['state'] == 'submitted'
             task_id = data['result']['id']
 
-            # Wait a bit for task to complete
-            await asyncio.sleep(0.5)
+            # Check task status with minimal polling
+            get_task_request = make_get_task_request(task_id, 'test-4')
 
-            # Check task status
-            get_task_request = {'jsonrpc': '2.0', 'id': 'test-4', 'method': 'tasks/get', 'params': {'id': task_id}}
+            # Poll for completion with short timeout
+            for _ in range(10):  # Try up to 10 times (1 second max)
+                response = await client.post('/', json=get_task_request)
+                assert response.status_code == 200
+                data = response.json()
+                if data['result']['status']['state'] == 'completed':
+                    break
+                await asyncio.sleep(0.1)  # Small delay between polls
+            else:
+                pytest.fail(f'Task did not complete, final state: {data["result"]["status"]["state"]}')
 
-            response = await client.post('/', json=get_task_request)
-            assert response.status_code == 200
-            data = response.json()
-            assert data['result']['status']['state'] == 'completed'
             assert len(data['result'].get('artifacts', [])) == 1
 
 
@@ -296,7 +320,7 @@ async def test_streaming_vs_non_streaming_endpoints(streaming_app):
 
 
 @pytest.mark.asyncio
-async def test_agent_card_shows_streaming_capability(streaming_app):
+async def test_agent_card_shows_streaming_capability(streaming_app: FastA2A) -> None:
     """Test that agent card correctly reports streaming capability."""
     async with LifespanManager(streaming_app):
         async with httpx.AsyncClient(
@@ -337,35 +361,15 @@ async def test_non_streaming_app():
 
 
 @pytest.mark.asyncio
-async def test_streaming_null_id_accepted(streaming_app):
+async def test_streaming_null_id_accepted(streaming_app: FastA2A) -> None:
     """Test streaming endpoint with explicit null ID - should work."""
     async with LifespanManager(streaming_app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
         ) as client:
             # Request with explicit null ID
-            request_data = {
-                'jsonrpc': '2.0',
-                'id': None,
-                'method': 'message/stream',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Test'}],
-                        'messageId': 'msg-null',
-                        'kind': 'message',
-                    }
-                },
-            }
-
-            events_received = []
-
-            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
-                async for sse in event_source.aiter_sse():
-                    event_data = json.loads(sse.data)
-                    events_received.append(event_data)
-                    # Stop after first event
-                    break
+            request_data = make_stream_request('Test', None, 'msg-null')
+            events_received = await collect_sse_events(client, request_data, lambda _: True)  # Stop after first event
 
             # Verify the event has null ID
             assert len(events_received) > 0
@@ -373,35 +377,15 @@ async def test_streaming_null_id_accepted(streaming_app):
 
 
 @pytest.mark.asyncio
-async def test_streaming_numeric_id_accepted(streaming_app):
+async def test_streaming_numeric_id_accepted(streaming_app: FastA2A) -> None:
     """Test streaming endpoint with numeric ID - should work per JSON-RPC spec."""
     async with LifespanManager(streaming_app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
         ) as client:
             # Request with numeric ID
-            request_data = {
-                'jsonrpc': '2.0',
-                'id': 12345,
-                'method': 'message/stream',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Test'}],
-                        'messageId': 'msg-numeric',
-                        'kind': 'message',
-                    }
-                },
-            }
-
-            events_received = []
-
-            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
-                async for sse in event_source.aiter_sse():
-                    event_data = json.loads(sse.data)
-                    events_received.append(event_data)
-                    # Stop after first event
-                    break
+            request_data = make_stream_request('Test', 12345, 'msg-numeric')
+            events_received = await collect_sse_events(client, request_data, lambda _: True)  # Stop after first event
 
             # Verify the event has numeric ID
             assert len(events_received) > 0
@@ -409,7 +393,7 @@ async def test_streaming_numeric_id_accepted(streaming_app):
 
 
 @pytest.mark.asyncio
-async def test_streaming_large_message(streaming_app):
+async def test_streaming_large_message(streaming_app: FastA2A) -> None:
     """Test streaming with a large message payload."""
     async with LifespanManager(streaming_app):
         async with httpx.AsyncClient(
@@ -417,31 +401,12 @@ async def test_streaming_large_message(streaming_app):
         ) as client:
             # Create a large message
             large_text = 'x' * 10000  # 10KB of text
-            request_data = {
-                'jsonrpc': '2.0',
-                'id': 'test-large',
-                'method': 'message/stream',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': large_text}],
-                        'messageId': 'msg-large',
-                        'kind': 'message',
-                    }
-                },
-            }
-
-            events_received = []
-
-            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
-                async for sse in event_source.aiter_sse():
-                    event_data = json.loads(sse.data)
-                    events_received.append(event_data)
+            request_data = make_stream_request(large_text, 'test-large', 'msg-large')
+            events_received = await collect_sse_events(client, request_data)
 
             # Should still process successfully
             assert len(events_received) > 0
             # Check we got a completed status
-            last_status = next(
-                e for e in reversed(events_received) if e.get('result', {}).get('kind') == 'status-update'
-            )
+            status_updates = get_status_updates(events_received)
+            last_status = status_updates[-1]
             assert last_status['result']['status']['state'] == 'completed'

--- a/tests/test_streaming_integration.py
+++ b/tests/test_streaming_integration.py
@@ -1,0 +1,447 @@
+"""Integration tests for the streaming endpoint."""
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+import pytest_asyncio
+from asgi_lifespan import LifespanManager
+from httpx_sse import aconnect_sse
+from sse_starlette.sse import AppStatus
+
+from fasta2a import FastA2A, Worker
+from fasta2a.broker import InMemoryBroker
+from fasta2a.schema import Artifact, Message, TaskIdParams, TaskSendParams
+from fasta2a.storage import InMemoryStorage
+
+Context = list[Message]
+"""The shape of the context you store in the storage."""
+
+
+@pytest.fixture(autouse=True)
+def reset_sse_app_status():
+    """Reset SSE global state between tests."""
+    AppStatus.should_exit_event = None
+    yield
+    AppStatus.should_exit_event = None
+
+
+class StreamingWorker(Worker[Context]):
+    """A test worker that emits streaming events."""
+
+    async def run_task(self, params: TaskSendParams) -> None:
+        task_id = params['id']
+        context_id = params['context_id']
+
+        # Load the task
+        task = await self.storage.load_task(task_id)
+        assert task is not None
+
+        # Update status to working
+        await self.storage.update_task(task_id, state='working')
+
+        # Emit initial status update
+        await self.broker.send_stream_event(
+            task_id,
+            {
+                'kind': 'status-update',
+                'task_id': task_id,
+                'context_id': context_id,
+                'status': {'state': 'working'},
+                'final': False,
+            },
+        )
+
+        # Simulate some work with incremental updates
+        result_parts = ['Hello', ' from', ' streaming', ' worker!']
+
+        for i, part in enumerate(result_parts):
+            # Create an artifact part
+            artifact: Artifact = {'artifact_id': 'result-1', 'parts': [{'kind': 'text', 'text': part}]}
+
+            # Emit artifact update
+            await self.broker.send_stream_event(
+                task_id,
+                {
+                    'kind': 'artifact-update',
+                    'task_id': task_id,
+                    'context_id': context_id,
+                    'artifact': artifact,
+                    'append': i > 0,  # Append after first part
+                    'last_chunk': i == len(result_parts) - 1,
+                },
+            )
+
+            # Small delay to simulate processing
+            await asyncio.sleep(0.05)
+
+        # Store the complete artifact
+        complete_artifact: Artifact = {
+            'artifact_id': 'result-1',
+            'parts': [{'kind': 'text', 'text': 'Hello from streaming worker!'}],
+        }
+
+        # Update task with final status
+        await self.storage.update_task(task_id, state='completed', new_artifacts=[complete_artifact])
+
+        # Emit final status update
+        await self.broker.send_stream_event(
+            task_id,
+            {
+                'kind': 'status-update',
+                'task_id': task_id,
+                'context_id': context_id,
+                'status': {'state': 'completed'},
+                'final': True,
+            },
+        )
+
+    async def cancel_task(self, params: TaskIdParams) -> None:
+        await self.storage.update_task(params['id'], state='canceled')
+
+    def build_message_history(self, history: list[Message]) -> list[Any]:
+        return history
+
+    def build_artifacts(self, result: Any) -> list[Artifact]:
+        return []
+
+
+@pytest_asyncio.fixture(scope='function')
+async def streaming_app():
+    """Create a FastA2A app with streaming enabled and a streaming worker."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    worker = StreamingWorker(storage=storage, broker=broker)
+
+    @asynccontextmanager
+    async def lifespan(app: FastA2A) -> AsyncIterator[None]:
+        async with app.task_manager:
+            async with worker.run():
+                yield
+
+    app = FastA2A(
+        storage=storage,
+        broker=broker,
+        streaming=True,  # Enable streaming
+        lifespan=lifespan,
+    )
+
+    return app
+
+
+# ===== Basic Streaming Functionality =====
+
+
+@pytest.mark.asyncio
+async def test_streaming_endpoint_basic(streaming_app):
+    """Test basic streaming functionality."""
+    async with LifespanManager(streaming_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
+        ) as client:
+            # Send a streaming request
+            request_data = {
+                'jsonrpc': '2.0',
+                'id': 'test-1',
+                'method': 'message/stream',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Test streaming'}],
+                        'messageId': 'msg-1',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            events_received = []
+
+            # Make streaming request using httpx-sse
+            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
+                # Collect all events
+                async for sse in event_source.aiter_sse():
+                    event_data = json.loads(sse.data)
+                    events_received.append(event_data)
+
+            # Verify we received events
+            assert len(events_received) > 0
+
+            # First event should be the task
+            first_event = events_received[0]
+            assert first_event['jsonrpc'] == '2.0'
+            assert first_event['id'] == 'test-1'
+            assert 'result' in first_event
+            assert first_event['result']['kind'] == 'task'
+            assert first_event['result']['status']['state'] == 'submitted'
+
+            # Should have status updates
+            status_updates = [e for e in events_received if e.get('result', {}).get('kind') == 'status-update']
+            assert len(status_updates) >= 2  # At least working and completed
+
+            # Should have artifact updates
+            artifact_updates = [e for e in events_received if e.get('result', {}).get('kind') == 'artifact-update']
+            assert len(artifact_updates) == 4  # 4 parts
+
+            # Last status update should be final
+            last_status = next(
+                e for e in reversed(events_received) if e.get('result', {}).get('kind') == 'status-update'
+            )
+            assert last_status['result']['status']['state'] == 'completed'
+            assert last_status['result']['final'] is True
+
+
+# ===== Artifact Streaming =====
+
+
+@pytest.mark.asyncio
+async def test_streaming_endpoint_incremental_artifacts(streaming_app):
+    """Test that artifacts are streamed incrementally."""
+    async with LifespanManager(streaming_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
+        ) as client:
+            request_data = {
+                'jsonrpc': '2.0',
+                'id': 'test-2',
+                'method': 'message/stream',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Test artifacts'}],
+                        'messageId': 'msg-2',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            artifact_events = []
+
+            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
+                async for sse in event_source.aiter_sse():
+                    event_data = json.loads(sse.data)
+                    if event_data.get('result', {}).get('kind') == 'artifact-update':
+                        artifact_events.append(event_data['result'])
+
+            # Verify artifact streaming
+            assert len(artifact_events) == 4
+
+            # First artifact should not append
+            assert 'append' not in artifact_events[0] or artifact_events[0]['append'] is False
+            assert artifact_events[0]['artifact']['parts'][0]['text'] == 'Hello'
+
+            # Subsequent artifacts should append
+            assert artifact_events[1]['append'] is True
+            assert artifact_events[1]['artifact']['parts'][0]['text'] == ' from'
+
+            assert artifact_events[2]['append'] is True
+            assert artifact_events[2]['artifact']['parts'][0]['text'] == ' streaming'
+
+            # Last artifact should be marked as last chunk
+            assert artifact_events[3]['append'] is True
+            assert artifact_events[3]['artifact']['parts'][0]['text'] == ' worker!'
+            assert artifact_events[3]['lastChunk'] is True
+
+
+# ===== Streaming vs Non-Streaming Comparison =====
+
+
+@pytest.mark.asyncio
+async def test_streaming_vs_non_streaming_endpoints(streaming_app):
+    """Test that both streaming and non-streaming endpoints work."""
+    async with LifespanManager(streaming_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
+        ) as client:
+            # First, test non-streaming endpoint
+            non_streaming_request = {
+                'jsonrpc': '2.0',
+                'id': 'test-3',
+                'method': 'message/send',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Non-streaming test'}],
+                        'messageId': 'msg-3',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            # Non-streaming should return immediately with task
+            response = await client.post('/', json=non_streaming_request)
+            assert response.status_code == 200
+            data = response.json()
+            assert data['result']['kind'] == 'task'
+            assert data['result']['status']['state'] == 'submitted'
+            task_id = data['result']['id']
+
+            # Wait a bit for task to complete
+            await asyncio.sleep(0.5)
+
+            # Check task status
+            get_task_request = {'jsonrpc': '2.0', 'id': 'test-4', 'method': 'tasks/get', 'params': {'id': task_id}}
+
+            response = await client.post('/', json=get_task_request)
+            assert response.status_code == 200
+            data = response.json()
+            assert data['result']['status']['state'] == 'completed'
+            assert len(data['result'].get('artifacts', [])) == 1
+
+
+# ===== Agent Card and Capabilities =====
+
+
+@pytest.mark.asyncio
+async def test_agent_card_shows_streaming_capability(streaming_app):
+    """Test that agent card correctly reports streaming capability."""
+    async with LifespanManager(streaming_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
+        ) as client:
+            response = await client.get('/.well-known/agent.json')
+            assert response.status_code == 200
+
+            agent_card = response.json()
+            assert agent_card['capabilities']['streaming'] is True
+            assert agent_card['capabilities']['pushNotifications'] is False
+            assert agent_card['capabilities']['stateTransitionHistory'] is False
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_app():
+    """Test app with streaming disabled."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+
+    app = FastA2A(
+        storage=storage,
+        broker=broker,
+        streaming=False,  # Streaming disabled
+    )
+
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url='http://test') as client:
+            # Check agent card
+            response = await client.get('/.well-known/agent.json')
+            assert response.status_code == 200
+
+            agent_card = response.json()
+            assert agent_card['capabilities']['streaming'] is False
+
+
+# ===== ID Validation Tests =====
+
+
+@pytest.mark.asyncio
+async def test_streaming_null_id_accepted(streaming_app):
+    """Test streaming endpoint with explicit null ID - should work."""
+    async with LifespanManager(streaming_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
+        ) as client:
+            # Request with explicit null ID
+            request_data = {
+                'jsonrpc': '2.0',
+                'id': None,
+                'method': 'message/stream',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Test'}],
+                        'messageId': 'msg-null',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            events_received = []
+
+            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
+                async for sse in event_source.aiter_sse():
+                    event_data = json.loads(sse.data)
+                    events_received.append(event_data)
+                    # Stop after first event
+                    break
+
+            # Verify the event has null ID
+            assert len(events_received) > 0
+            assert events_received[0]['id'] is None
+
+
+@pytest.mark.asyncio
+async def test_streaming_numeric_id_accepted(streaming_app):
+    """Test streaming endpoint with numeric ID - should work per JSON-RPC spec."""
+    async with LifespanManager(streaming_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
+        ) as client:
+            # Request with numeric ID
+            request_data = {
+                'jsonrpc': '2.0',
+                'id': 12345,
+                'method': 'message/stream',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Test'}],
+                        'messageId': 'msg-numeric',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            events_received = []
+
+            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
+                async for sse in event_source.aiter_sse():
+                    event_data = json.loads(sse.data)
+                    events_received.append(event_data)
+                    # Stop after first event
+                    break
+
+            # Verify the event has numeric ID
+            assert len(events_received) > 0
+            assert events_received[0]['id'] == 12345
+
+
+@pytest.mark.asyncio
+async def test_streaming_large_message(streaming_app):
+    """Test streaming with a large message payload."""
+    async with LifespanManager(streaming_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=streaming_app), base_url='http://test'
+        ) as client:
+            # Create a large message
+            large_text = 'x' * 10000  # 10KB of text
+            request_data = {
+                'jsonrpc': '2.0',
+                'id': 'test-large',
+                'method': 'message/stream',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': large_text}],
+                        'messageId': 'msg-large',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            events_received = []
+
+            async with aconnect_sse(client, 'POST', '/', json=request_data) as event_source:
+                async for sse in event_source.aiter_sse():
+                    event_data = json.loads(sse.data)
+                    events_received.append(event_data)
+
+            # Should still process successfully
+            assert len(events_received) > 0
+            # Check we got a completed status
+            last_status = next(
+                e for e in reversed(events_received) if e.get('result', {}).get('kind') == 'status-update'
+            )
+            assert last_status['result']['status']['state'] == 'completed'

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,0 +1,438 @@
+"""Tests for TaskManager class."""
+
+import pytest
+
+from fasta2a.broker import InMemoryBroker
+from fasta2a.schema import TaskIdParams, TaskSendParams
+from fasta2a.storage import InMemoryStorage
+from fasta2a.task_manager import TaskManager
+
+
+@pytest.mark.asyncio
+async def test_task_manager_context_manager():
+    """Test TaskManager as async context manager."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    # Not running before entering context
+    assert not task_manager.is_running
+
+    async with task_manager:
+        # Should be running inside context
+        assert task_manager.is_running
+
+    # Not running after exiting context
+    assert not task_manager.is_running
+
+
+@pytest.mark.asyncio
+async def test_task_manager_exit_without_enter():
+    """Test exiting TaskManager without entering raises error."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    with pytest.raises(RuntimeError, match='TaskManager was not properly initialized'):
+        await task_manager.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_send_message():
+    """Test send_message method."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    async with broker:
+        async with task_manager:
+            request = {
+                'jsonrpc': '2.0',
+                'id': 'req-1',
+                'method': 'message/send',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello'}],
+                        'messageId': 'msg-1',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            response = await task_manager.send_message(request)
+
+            assert response['jsonrpc'] == '2.0'
+            assert response['id'] == 'req-1'
+            assert 'result' in response
+
+            task = response['result']
+            assert task['kind'] == 'task'
+            assert task['status']['state'] == 'submitted'
+            assert 'id' in task
+            assert 'contextId' in task
+
+
+@pytest.mark.asyncio
+async def test_send_message_with_context_id():
+    """Test send_message with explicit context_id."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    async with broker:
+        async with task_manager:
+            request = {
+                'jsonrpc': '2.0',
+                'id': 'req-2',
+                'method': 'message/send',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello'}],
+                        'messageId': 'msg-2',
+                        'kind': 'message',
+                        'context_id': 'custom-context-123',
+                    }
+                },
+            }
+
+            response = await task_manager.send_message(request)
+            task = response['result']
+            assert task['contextId'] == 'custom-context-123'
+
+
+@pytest.mark.asyncio
+async def test_send_message_with_history_length():
+    """Test send_message with history_length configuration."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    # Mock broker.run_task to capture params
+    run_task_calls = []
+    original_run_task = broker.run_task
+
+    async def mock_run_task(params: TaskSendParams):
+        run_task_calls.append(params)
+        return await original_run_task(params)
+
+    broker.run_task = mock_run_task
+
+    async with broker:
+        async with task_manager:
+            request = {
+                'jsonrpc': '2.0',
+                'id': 'req-3',
+                'method': 'message/send',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello'}],
+                        'messageId': 'msg-3',
+                        'kind': 'message',
+                    },
+                    'configuration': {'history_length': 10},
+                },
+            }
+
+            await task_manager.send_message(request)
+
+            # Verify history_length was passed to broker
+            assert len(run_task_calls) == 1
+            assert run_task_calls[0]['history_length'] == 10
+
+
+@pytest.mark.asyncio
+async def test_get_task():
+    """Test get_task method."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    async with broker:
+        async with task_manager:
+            # First create a task
+            send_request = {
+                'jsonrpc': '2.0',
+                'id': 'req-4',
+                'method': 'message/send',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello'}],
+                        'messageId': 'msg-4',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            send_response = await task_manager.send_message(send_request)
+            task_id = send_response['result']['id']
+
+            # Now get the task
+            get_request = {'jsonrpc': '2.0', 'id': 'req-5', 'method': 'tasks/get', 'params': {'id': task_id}}
+
+            get_response = await task_manager.get_task(get_request)
+
+            assert get_response['jsonrpc'] == '2.0'
+            assert get_response['id'] == 'req-5'
+            assert 'result' in get_response
+            assert get_response['result']['id'] == task_id
+
+
+@pytest.mark.asyncio
+async def test_get_task_not_found():
+    """Test get_task with non-existent task."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    async with broker:
+        async with task_manager:
+            get_request = {
+                'jsonrpc': '2.0',
+                'id': 'req-6',
+                'method': 'tasks/get',
+                'params': {'id': 'non-existent-task'},
+            }
+
+            get_response = await task_manager.get_task(get_request)
+
+            assert get_response['jsonrpc'] == '2.0'
+            assert get_response['id'] == 'req-6'
+            assert 'error' in get_response
+            assert get_response['error']['code'] == -32001
+            assert get_response['error']['message'] == 'Task not found'
+
+
+@pytest.mark.asyncio
+async def test_get_task_with_history_length():
+    """Test get_task with history_length parameter."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    # Mock storage.load_task to capture history_length
+    load_task_calls = []
+    original_load_task = storage.load_task
+
+    async def mock_load_task(task_id: str, history_length: int | None = None):
+        load_task_calls.append((task_id, history_length))
+        return await original_load_task(task_id, history_length)
+
+    storage.load_task = mock_load_task
+
+    async with broker:
+        async with task_manager:
+            # Create a task first
+            send_request = {
+                'jsonrpc': '2.0',
+                'id': 'req-7',
+                'method': 'message/send',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello'}],
+                        'messageId': 'msg-7',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            send_response = await task_manager.send_message(send_request)
+            task_id = send_response['result']['id']
+
+            # Get task with history_length
+            get_request = {
+                'jsonrpc': '2.0',
+                'id': 'req-8',
+                'method': 'tasks/get',
+                'params': {'id': task_id, 'history_length': 5},
+            }
+
+            await task_manager.get_task(get_request)
+
+            # Verify history_length was passed
+            assert any(call[0] == task_id and call[1] == 5 for call in load_task_calls)
+
+
+@pytest.mark.asyncio
+async def test_cancel_task():
+    """Test cancel_task method."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    # Track cancel calls
+    cancel_calls = []
+    original_cancel = broker.cancel_task
+
+    async def mock_cancel(params: TaskIdParams):
+        cancel_calls.append(params)
+        return await original_cancel(params)
+
+    broker.cancel_task = mock_cancel
+
+    async with broker:
+        async with task_manager:
+            # Create a task first
+            send_request = {
+                'jsonrpc': '2.0',
+                'id': 'req-9',
+                'method': 'message/send',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello'}],
+                        'messageId': 'msg-9',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            send_response = await task_manager.send_message(send_request)
+            task_id = send_response['result']['id']
+
+            # Cancel the task
+            cancel_request = {'jsonrpc': '2.0', 'id': 'req-10', 'method': 'tasks/cancel', 'params': {'id': task_id}}
+
+            cancel_response = await task_manager.cancel_task(cancel_request)
+
+            assert cancel_response['jsonrpc'] == '2.0'
+            assert cancel_response['id'] == 'req-10'
+            assert 'result' in cancel_response
+            assert cancel_response['result']['id'] == task_id
+
+            # Verify broker.cancel_task was called
+            assert len(cancel_calls) == 1
+            assert cancel_calls[0]['id'] == task_id
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_not_found():
+    """Test cancel_task with non-existent task."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    async with broker:
+        async with task_manager:
+            cancel_request = {
+                'jsonrpc': '2.0',
+                'id': 'req-11',
+                'method': 'tasks/cancel',
+                'params': {'id': 'non-existent-task'},
+            }
+
+            cancel_response = await task_manager.cancel_task(cancel_request)
+
+            assert cancel_response['jsonrpc'] == '2.0'
+            assert cancel_response['id'] == 'req-11'
+            assert 'error' in cancel_response
+            assert cancel_response['error']['code'] == -32001
+            assert cancel_response['error']['message'] == 'Task not found'
+
+
+@pytest.mark.asyncio
+async def test_stream_message():
+    """Test stream_message method."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    async with broker:
+        async with task_manager:
+            request = {
+                'jsonrpc': '2.0',
+                'id': 'req-12',
+                'method': 'message/stream',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello streaming'}],
+                        'messageId': 'msg-12',
+                        'kind': 'message',
+                    }
+                },
+            }
+
+            events = []
+            async for event in task_manager.stream_message(request):
+                events.append(event)
+                # Simulate sending a final event to end the stream
+                if len(events) == 1 and event['kind'] == 'task':
+                    task_id = event['id']
+                    await broker.send_stream_event(
+                        task_id,
+                        {
+                            'kind': 'status-update',
+                            'task_id': task_id,
+                            'context_id': event['contextId'],
+                            'status': {'state': 'completed'},
+                            'final': True,
+                        },
+                    )
+
+            # Should have received at least the task and final status
+            assert len(events) >= 2
+            assert events[0]['kind'] == 'task'
+            assert events[-1]['kind'] == 'status-update'
+            assert events[-1]['final'] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_message_with_context_and_history():
+    """Test stream_message with context_id and history_length."""
+    storage = InMemoryStorage()
+    broker = InMemoryBroker()
+    task_manager = TaskManager(broker=broker, storage=storage)
+
+    # Track run_task calls
+    run_task_calls = []
+
+    async def mock_run(params: TaskSendParams):
+        run_task_calls.append(params)
+        # Don't actually run to avoid background tasks
+        pass
+
+    broker.run_task = mock_run
+
+    async with broker:
+        async with task_manager:
+            request = {
+                'jsonrpc': '2.0',
+                'id': 'req-13',
+                'method': 'message/stream',
+                'params': {
+                    'message': {
+                        'role': 'user',
+                        'parts': [{'kind': 'text', 'text': 'Hello'}],
+                        'messageId': 'msg-13',
+                        'kind': 'message',
+                        'context_id': 'stream-context-123',
+                    },
+                    'configuration': {'history_length': 15},
+                },
+            }
+
+            # Get first event (the task)
+            async for event in task_manager.stream_message(request):
+                if event['kind'] == 'task':
+                    task_id = event['id']
+                    # End stream immediately
+                    await broker.send_stream_event(
+                        task_id,
+                        {
+                            'kind': 'status-update',
+                            'task_id': task_id,
+                            'context_id': 'stream-context-123',
+                            'status': {'state': 'completed'},
+                            'final': True,
+                        },
+                    )
+
+            # Verify params passed to broker
+            assert len(run_task_calls) == 1
+            assert run_task_calls[0]['context_id'] == 'stream-context-123'
+            assert run_task_calls[0]['history_length'] == 15

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,438 +1,516 @@
 """Tests for TaskManager class."""
 
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any, Literal
+from unittest.mock import AsyncMock
+
 import pytest
+import pytest_asyncio
+from pytest_mock import MockerFixture
 
 from fasta2a.broker import InMemoryBroker
-from fasta2a.schema import TaskIdParams, TaskSendParams
+from fasta2a.schema import (
+    CancelTaskRequest,
+    GetTaskRequest,
+    Message,
+    MessageSendConfiguration,
+    MessageSendParams,
+    SendMessageRequest,
+    StreamMessageRequest,
+    TaskQueryParams,
+    TaskSendParams,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+    TextPart,
+)
 from fasta2a.storage import InMemoryStorage
 from fasta2a.task_manager import TaskManager
 
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def storage() -> InMemoryStorage:
+    """Create an InMemoryStorage instance."""
+    return InMemoryStorage()
+
+
+@pytest.fixture
+def broker() -> InMemoryBroker:
+    """Create an InMemoryBroker instance."""
+    return InMemoryBroker()
+
+
+@pytest.fixture
+def task_manager_factory(broker: InMemoryBroker, storage: InMemoryStorage) -> TaskManager:
+    """Create a TaskManager instance without entering contexts."""
+    return TaskManager(broker=broker, storage=storage)
+
+
+@pytest_asyncio.fixture
+async def task_manager(
+    broker: InMemoryBroker, storage: InMemoryStorage
+) -> AsyncIterator[tuple[TaskManager, InMemoryBroker, InMemoryStorage]]:
+    """Create and enter TaskManager with broker contexts.
+
+    Yields:
+        tuple: (task_manager, broker, storage) for tests that need access to all components
+    """
+    tm = TaskManager(broker=broker, storage=storage)
+    async with broker:
+        async with tm:
+            yield tm, broker, storage
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+def send_message_request(
+    message: Message, req_id: str = 'req-1', configuration: MessageSendConfiguration | None = None
+) -> SendMessageRequest:
+    """Build a SendMessageRequest."""
+    params: MessageSendParams = {'message': message}
+    if configuration:
+        params['configuration'] = configuration
+    return {
+        'jsonrpc': '2.0',
+        'id': req_id,
+        'method': 'message/send',
+        'params': params,
+    }
+
+
+def stream_message_request(
+    message: Message, req_id: str = 'req-1', configuration: MessageSendConfiguration | None = None
+) -> StreamMessageRequest:
+    """Build a StreamMessageRequest."""
+    params: MessageSendParams = {'message': message}
+    if configuration:
+        params['configuration'] = configuration
+    return {
+        'jsonrpc': '2.0',
+        'id': req_id,
+        'method': 'message/stream',
+        'params': params,
+    }
+
+
+def get_task_request(task_id: str, req_id: str = 'req-1', history_length: int | None = None) -> GetTaskRequest:
+    """Build a GetTaskRequest."""
+    params: TaskQueryParams = {'id': task_id}
+    if history_length is not None:
+        params['history_length'] = history_length
+    return {
+        'jsonrpc': '2.0',
+        'id': req_id,
+        'method': 'tasks/get',
+        'params': params,
+    }
+
+
+def cancel_task_request(task_id: str, req_id: str = 'req-1') -> CancelTaskRequest:
+    """Build a CancelTaskRequest."""
+    return {
+        'jsonrpc': '2.0',
+        'id': req_id,
+        'method': 'tasks/cancel',
+        'params': {'id': task_id},
+    }
+
+
+def create_test_message(
+    role: Literal['user', 'agent'] = 'user',
+    text: str = 'Hello',
+    message_id: str = 'msg-1',
+    context_id: str | None = None,
+) -> Message:
+    """Helper to create a properly typed Message."""
+    text_part: TextPart = {
+        'kind': 'text',
+        'text': text,
+    }
+    message: Message = {
+        'role': role,  # No cast needed now!
+        'parts': [text_part],
+        'message_id': message_id,
+        'kind': 'message',
+    }
+    if context_id is not None:
+        message['context_id'] = context_id
+    return message
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
 
 @pytest.mark.asyncio
-async def test_task_manager_context_manager():
+async def test_task_manager_context_manager(task_manager_factory: TaskManager):
     """Test TaskManager as async context manager."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
-
     # Not running before entering context
-    assert not task_manager.is_running
+    assert not task_manager_factory.is_running
 
-    async with task_manager:
+    async with task_manager_factory:
         # Should be running inside context
-        assert task_manager.is_running
+        assert task_manager_factory.is_running
 
     # Not running after exiting context
-    assert not task_manager.is_running
+    assert not task_manager_factory.is_running
 
 
 @pytest.mark.asyncio
-async def test_task_manager_exit_without_enter():
+async def test_task_manager_exit_without_enter(task_manager_factory: TaskManager):
     """Test exiting TaskManager without entering raises error."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
-
     with pytest.raises(RuntimeError, match='TaskManager was not properly initialized'):
-        await task_manager.__aexit__(None, None, None)
+        await task_manager_factory.__aexit__(None, None, None)
 
 
 @pytest.mark.asyncio
-async def test_send_message():
+async def test_send_message(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test send_message method."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    async with broker:
-        async with task_manager:
-            request = {
-                'jsonrpc': '2.0',
-                'id': 'req-1',
-                'method': 'message/send',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello'}],
-                        'messageId': 'msg-1',
-                        'kind': 'message',
-                    }
-                },
-            }
+    # Mock broker.run_task
+    mock_run_task = mocker.patch.object(broker, 'run_task', new_callable=AsyncMock)
 
-            response = await task_manager.send_message(request)
+    # Create and send message
+    message = create_test_message(text='Hello', message_id='msg-1')
+    request = send_message_request(message, req_id='req-1')
 
-            assert response['jsonrpc'] == '2.0'
-            assert response['id'] == 'req-1'
-            assert 'result' in response
+    response = await tm.send_message(request)
 
-            task = response['result']
-            assert task['kind'] == 'task'
-            assert task['status']['state'] == 'submitted'
-            assert 'id' in task
-            assert 'contextId' in task
+    # Verify response
+    assert response['jsonrpc'] == '2.0'
+    assert response['id'] == 'req-1'
+    assert 'result' in response
+
+    task = response['result']
+    assert task['kind'] == 'task'
+    assert task['status']['state'] == 'submitted'
+    assert 'id' in task
+    assert 'context_id' in task
+
+    # Verify broker.run_task was called
+    mock_run_task.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_send_message_with_context_id():
+async def test_send_message_with_context_id(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test send_message with explicit context_id."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    async with broker:
-        async with task_manager:
-            request = {
-                'jsonrpc': '2.0',
-                'id': 'req-2',
-                'method': 'message/send',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello'}],
-                        'messageId': 'msg-2',
-                        'kind': 'message',
-                        'context_id': 'custom-context-123',
-                    }
-                },
-            }
+    # Mock broker.run_task
+    mocker.patch.object(broker, 'run_task', new_callable=AsyncMock)
 
-            response = await task_manager.send_message(request)
-            task = response['result']
-            assert task['contextId'] == 'custom-context-123'
+    # Create message with context_id
+    message = create_test_message(text='Hello', message_id='msg-2', context_id='custom-context-123')
+    request = send_message_request(message, req_id='req-2')
+
+    response = await tm.send_message(request)
+
+    assert 'result' in response
+    task = response['result']
+    assert 'context_id' in task
+    assert task['context_id'] == 'custom-context-123'
 
 
 @pytest.mark.asyncio
-async def test_send_message_with_history_length():
+async def test_send_message_with_history_length(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test send_message with history_length configuration."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    # Mock broker.run_task to capture params
-    run_task_calls = []
-    original_run_task = broker.run_task
+    # Mock broker.run_task
+    mock_run_task = mocker.patch.object(broker, 'run_task', new_callable=AsyncMock)
 
-    async def mock_run_task(params: TaskSendParams):
-        run_task_calls.append(params)
-        return await original_run_task(params)
+    # Create message with configuration
+    message = create_test_message(text='Hello', message_id='msg-3')
+    configuration: MessageSendConfiguration = {
+        'history_length': 10,
+        'accepted_output_modes': ['text/plain'],
+    }
+    request = send_message_request(message, req_id='req-3', configuration=configuration)
 
-    broker.run_task = mock_run_task
+    await tm.send_message(request)
 
-    async with broker:
-        async with task_manager:
-            request = {
-                'jsonrpc': '2.0',
-                'id': 'req-3',
-                'method': 'message/send',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello'}],
-                        'messageId': 'msg-3',
-                        'kind': 'message',
-                    },
-                    'configuration': {'history_length': 10},
-                },
-            }
-
-            await task_manager.send_message(request)
-
-            # Verify history_length was passed to broker
-            assert len(run_task_calls) == 1
-            assert run_task_calls[0]['history_length'] == 10
+    # Verify history_length was passed to broker
+    mock_run_task.assert_called_once()
+    call_args = mock_run_task.call_args[0][0]
+    assert 'history_length' in call_args
+    assert call_args['history_length'] == 10
 
 
 @pytest.mark.asyncio
-async def test_get_task():
+async def test_get_task(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test get_task method."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    async with broker:
-        async with task_manager:
-            # First create a task
-            send_request = {
-                'jsonrpc': '2.0',
-                'id': 'req-4',
-                'method': 'message/send',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello'}],
-                        'messageId': 'msg-4',
-                        'kind': 'message',
-                    }
-                },
-            }
+    # Mock broker.run_task
+    mocker.patch.object(broker, 'run_task', new_callable=AsyncMock)
 
-            send_response = await task_manager.send_message(send_request)
-            task_id = send_response['result']['id']
+    # First create a task
+    message = create_test_message(text='Hello', message_id='msg-4')
+    send_request = send_message_request(message, req_id='req-4')
 
-            # Now get the task
-            get_request = {'jsonrpc': '2.0', 'id': 'req-5', 'method': 'tasks/get', 'params': {'id': task_id}}
+    send_response = await tm.send_message(send_request)
+    assert 'result' in send_response
+    assert 'id' in send_response['result']
+    task_id = send_response['result']['id']
 
-            get_response = await task_manager.get_task(get_request)
+    # Now get the task
+    get_request = get_task_request(task_id, req_id='req-5')
+    get_response = await tm.get_task(get_request)
 
-            assert get_response['jsonrpc'] == '2.0'
-            assert get_response['id'] == 'req-5'
-            assert 'result' in get_response
-            assert get_response['result']['id'] == task_id
+    assert get_response['jsonrpc'] == '2.0'
+    assert get_response['id'] == 'req-5'
+    assert 'result' in get_response
+    assert get_response['result']['id'] == task_id
 
 
 @pytest.mark.asyncio
-async def test_get_task_not_found():
+async def test_get_task_not_found(task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage]) -> None:
     """Test get_task with non-existent task."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, _broker, _storage = task_manager
 
-    async with broker:
-        async with task_manager:
-            get_request = {
-                'jsonrpc': '2.0',
-                'id': 'req-6',
-                'method': 'tasks/get',
-                'params': {'id': 'non-existent-task'},
-            }
+    get_request = get_task_request('non-existent-task', req_id='req-6')
+    get_response = await tm.get_task(get_request)
 
-            get_response = await task_manager.get_task(get_request)
-
-            assert get_response['jsonrpc'] == '2.0'
-            assert get_response['id'] == 'req-6'
-            assert 'error' in get_response
-            assert get_response['error']['code'] == -32001
-            assert get_response['error']['message'] == 'Task not found'
+    assert get_response['jsonrpc'] == '2.0'
+    assert get_response['id'] == 'req-6'
+    assert 'error' in get_response
+    assert get_response['error']['code'] == -32001
+    assert get_response['error']['message'] == 'Task not found'
 
 
 @pytest.mark.asyncio
-async def test_get_task_with_history_length():
+async def test_get_task_with_history_length(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test get_task with history_length parameter."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, storage = task_manager
 
-    # Mock storage.load_task to capture history_length
-    load_task_calls = []
+    # Mock broker.run_task
+    mocker.patch.object(broker, 'run_task', new_callable=AsyncMock)
+
+    # Mock storage.load_task to track calls
     original_load_task = storage.load_task
+    mock_load_task = mocker.patch.object(storage, 'load_task', new_callable=AsyncMock)
+    # Make it return a valid task by calling the original
+    mock_load_task.side_effect = original_load_task
 
-    async def mock_load_task(task_id: str, history_length: int | None = None):
-        load_task_calls.append((task_id, history_length))
-        return await original_load_task(task_id, history_length)
+    # Create a task first
+    message = create_test_message(text='Hello', message_id='msg-7')
+    send_request = send_message_request(message, req_id='req-7')
 
-    storage.load_task = mock_load_task
+    send_response = await tm.send_message(send_request)
+    assert 'result' in send_response
+    assert 'id' in send_response['result']
+    task_id = send_response['result']['id']
 
-    async with broker:
-        async with task_manager:
-            # Create a task first
-            send_request = {
-                'jsonrpc': '2.0',
-                'id': 'req-7',
-                'method': 'message/send',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello'}],
-                        'messageId': 'msg-7',
-                        'kind': 'message',
-                    }
-                },
-            }
+    # Get task with history_length
+    get_request = get_task_request(task_id, req_id='req-8', history_length=5)
+    await tm.get_task(get_request)
 
-            send_response = await task_manager.send_message(send_request)
-            task_id = send_response['result']['id']
-
-            # Get task with history_length
-            get_request = {
-                'jsonrpc': '2.0',
-                'id': 'req-8',
-                'method': 'tasks/get',
-                'params': {'id': task_id, 'history_length': 5},
-            }
-
-            await task_manager.get_task(get_request)
-
-            # Verify history_length was passed
-            assert any(call[0] == task_id and call[1] == 5 for call in load_task_calls)
+    # Verify history_length was passed
+    mock_load_task.assert_called_with(task_id, 5)
 
 
 @pytest.mark.asyncio
-async def test_cancel_task():
+async def test_cancel_task(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test cancel_task method."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    # Track cancel calls
-    cancel_calls = []
-    original_cancel = broker.cancel_task
+    # Mock broker methods
+    mocker.patch.object(broker, 'run_task', new_callable=AsyncMock)
+    mock_cancel_task = mocker.patch.object(broker, 'cancel_task', new_callable=AsyncMock)
 
-    async def mock_cancel(params: TaskIdParams):
-        cancel_calls.append(params)
-        return await original_cancel(params)
+    # Create a task first
+    message = create_test_message(text='Hello', message_id='msg-9')
+    send_request = send_message_request(message, req_id='req-9')
 
-    broker.cancel_task = mock_cancel
+    send_response = await tm.send_message(send_request)
+    assert 'result' in send_response
+    assert 'id' in send_response['result']
+    task_id = send_response['result']['id']
 
-    async with broker:
-        async with task_manager:
-            # Create a task first
-            send_request = {
-                'jsonrpc': '2.0',
-                'id': 'req-9',
-                'method': 'message/send',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello'}],
-                        'messageId': 'msg-9',
-                        'kind': 'message',
-                    }
-                },
-            }
+    # Cancel the task
+    cancel_request = cancel_task_request(task_id, req_id='req-10')
+    cancel_response = await tm.cancel_task(cancel_request)
 
-            send_response = await task_manager.send_message(send_request)
-            task_id = send_response['result']['id']
+    assert cancel_response['jsonrpc'] == '2.0'
+    assert cancel_response['id'] == 'req-10'
+    assert 'result' in cancel_response
+    assert cancel_response['result']['id'] == task_id
 
-            # Cancel the task
-            cancel_request = {'jsonrpc': '2.0', 'id': 'req-10', 'method': 'tasks/cancel', 'params': {'id': task_id}}
-
-            cancel_response = await task_manager.cancel_task(cancel_request)
-
-            assert cancel_response['jsonrpc'] == '2.0'
-            assert cancel_response['id'] == 'req-10'
-            assert 'result' in cancel_response
-            assert cancel_response['result']['id'] == task_id
-
-            # Verify broker.cancel_task was called
-            assert len(cancel_calls) == 1
-            assert cancel_calls[0]['id'] == task_id
+    # Verify broker.cancel_task was called
+    mock_cancel_task.assert_called_once()
+    assert mock_cancel_task.call_args[0][0]['id'] == task_id
 
 
 @pytest.mark.asyncio
-async def test_cancel_task_not_found():
+async def test_cancel_task_not_found(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test cancel_task with non-existent task."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    async with broker:
-        async with task_manager:
-            cancel_request = {
-                'jsonrpc': '2.0',
-                'id': 'req-11',
-                'method': 'tasks/cancel',
-                'params': {'id': 'non-existent-task'},
-            }
+    # Mock broker.cancel_task
+    mocker.patch.object(broker, 'cancel_task', new_callable=AsyncMock)
 
-            cancel_response = await task_manager.cancel_task(cancel_request)
+    cancel_request = cancel_task_request('non-existent-task', req_id='req-11')
+    cancel_response = await tm.cancel_task(cancel_request)
 
-            assert cancel_response['jsonrpc'] == '2.0'
-            assert cancel_response['id'] == 'req-11'
-            assert 'error' in cancel_response
-            assert cancel_response['error']['code'] == -32001
-            assert cancel_response['error']['message'] == 'Task not found'
+    assert cancel_response['jsonrpc'] == '2.0'
+    assert cancel_response['id'] == 'req-11'
+    assert 'error' in cancel_response
+    assert cancel_response['error']['code'] == -32001
+    assert cancel_response['error']['message'] == 'Task not found'
 
 
 @pytest.mark.asyncio
-async def test_stream_message():
+async def test_stream_message(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test stream_message method."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    async with broker:
-        async with task_manager:
-            request = {
-                'jsonrpc': '2.0',
-                'id': 'req-12',
-                'method': 'message/stream',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello streaming'}],
-                        'messageId': 'msg-12',
-                        'kind': 'message',
-                    }
-                },
-            }
+    # Track the task info for our simulated worker
+    task_info: dict[str, str | None] = {'task_id': None, 'context_id': None}
 
-            events = []
-            async for event in task_manager.stream_message(request):
-                events.append(event)
-                # Simulate sending a final event to end the stream
-                if len(events) == 1 and event['kind'] == 'task':
-                    task_id = event['id']
-                    await broker.send_stream_event(
-                        task_id,
-                        {
-                            'kind': 'status-update',
-                            'task_id': task_id,
-                            'context_id': event['contextId'],
-                            'status': {'state': 'completed'},
-                            'final': True,
-                        },
-                    )
+    # Create side effect for simulating worker
+    async def simulate_worker(params: TaskSendParams):
+        # Capture task info
+        task_info['task_id'] = params['id']
+        task_info['context_id'] = params['context_id']
 
-            # Should have received at least the task and final status
-            assert len(events) >= 2
-            assert events[0]['kind'] == 'task'
-            assert events[-1]['kind'] == 'status-update'
-            assert events[-1]['final'] is True
+        # Simulate worker behavior in background
+        async def worker_task():
+            # Small delay to ensure subscriber is ready
+            await asyncio.sleep(0.1)
+
+            # Send working status
+            if task_info['task_id'] is not None and task_info['context_id'] is not None:
+                status: TaskStatus = {'state': 'working'}
+                event: TaskStatusUpdateEvent = {
+                    'kind': 'status-update',
+                    'task_id': task_info['task_id'],
+                    'context_id': task_info['context_id'],
+                    'status': status,
+                    'final': False,
+                }
+                await broker.send_stream_event(task_info['task_id'], event)
+
+            # Small delay for processing
+            await asyncio.sleep(0.1)
+
+            # Send completion status
+            if task_info['task_id'] is not None and task_info['context_id'] is not None:
+                status: TaskStatus = {'state': 'completed'}
+                event: TaskStatusUpdateEvent = {
+                    'kind': 'status-update',
+                    'task_id': task_info['task_id'],
+                    'context_id': task_info['context_id'],
+                    'status': status,
+                    'final': True,
+                }
+                await broker.send_stream_event(task_info['task_id'], event)
+
+        # Start worker simulation in background
+        asyncio.create_task(worker_task())
+
+    # Mock broker.run_task with side effect
+    mocker.patch.object(broker, 'run_task', new_callable=AsyncMock, side_effect=simulate_worker)
+
+    # Create stream request
+    message = create_test_message(text='Hello streaming', message_id='msg-12')
+    request = stream_message_request(message, req_id='req-12')
+
+    # Collect events
+    events: list[Any] = []
+    async for event in tm.stream_message(request):
+        events.append(event)
+
+    # Should have received the task and status updates
+    assert len(events) == 3  # task, working status, completed status
+    assert events[0]['kind'] == 'task'
+    assert events[1]['kind'] == 'status-update'
+    assert events[1]['status']['state'] == 'working'
+    assert events[2]['kind'] == 'status-update'
+    assert events[2]['status']['state'] == 'completed'
+    assert events[2]['final'] is True
 
 
 @pytest.mark.asyncio
-async def test_stream_message_with_context_and_history():
+async def test_stream_message_with_context_and_history(
+    task_manager: tuple[TaskManager, InMemoryBroker, InMemoryStorage], mocker: MockerFixture
+) -> None:
     """Test stream_message with context_id and history_length."""
-    storage = InMemoryStorage()
-    broker = InMemoryBroker()
-    task_manager = TaskManager(broker=broker, storage=storage)
+    tm, broker, _storage = task_manager
 
-    # Track run_task calls
-    run_task_calls = []
+    # Create side effect for quick completion
+    async def simulate_quick_completion(params: TaskSendParams):
+        # Simulate worker behavior in background
+        async def worker_task():
+            # Small delay to ensure subscriber is ready
+            await asyncio.sleep(0.1)
 
-    async def mock_run(params: TaskSendParams):
-        run_task_calls.append(params)
-        # Don't actually run to avoid background tasks
-        pass
-
-    broker.run_task = mock_run
-
-    async with broker:
-        async with task_manager:
-            request = {
-                'jsonrpc': '2.0',
-                'id': 'req-13',
-                'method': 'message/stream',
-                'params': {
-                    'message': {
-                        'role': 'user',
-                        'parts': [{'kind': 'text', 'text': 'Hello'}],
-                        'messageId': 'msg-13',
-                        'kind': 'message',
-                        'context_id': 'stream-context-123',
-                    },
-                    'configuration': {'history_length': 15},
-                },
+            # Send completion status immediately for this test
+            status: TaskStatus = {'state': 'completed'}
+            event: TaskStatusUpdateEvent = {
+                'kind': 'status-update',
+                'task_id': params['id'],
+                'context_id': params['context_id'],
+                'status': status,
+                'final': True,
             }
+            await broker.send_stream_event(params['id'], event)
 
-            # Get first event (the task)
-            async for event in task_manager.stream_message(request):
-                if event['kind'] == 'task':
-                    task_id = event['id']
-                    # End stream immediately
-                    await broker.send_stream_event(
-                        task_id,
-                        {
-                            'kind': 'status-update',
-                            'task_id': task_id,
-                            'context_id': 'stream-context-123',
-                            'status': {'state': 'completed'},
-                            'final': True,
-                        },
-                    )
+        # Start worker simulation in background
+        asyncio.create_task(worker_task())
 
-            # Verify params passed to broker
-            assert len(run_task_calls) == 1
-            assert run_task_calls[0]['context_id'] == 'stream-context-123'
-            assert run_task_calls[0]['history_length'] == 15
+    # Mock broker.run_task with side effect
+    mock_run_task = mocker.patch.object(
+        broker, 'run_task', new_callable=AsyncMock, side_effect=simulate_quick_completion
+    )
+
+    # Create message with context and configuration
+    message = create_test_message(text='Hello', message_id='msg-13', context_id='stream-context-123')
+    configuration: MessageSendConfiguration = {
+        'history_length': 15,
+        'accepted_output_modes': ['text/plain'],
+    }
+    request = stream_message_request(message, req_id='req-13', configuration=configuration)
+
+    # Collect all events
+    events: list[Any] = []
+    async for event in tm.stream_message(request):
+        events.append(event)
+
+    # Verify we got the task and completion status
+    assert len(events) == 2
+    assert events[0]['kind'] == 'task'
+    assert events[0]['context_id'] == 'stream-context-123'
+    assert events[1]['kind'] == 'status-update'
+    assert events[1]['final'] is True
+
+    # Verify params passed to broker
+    mock_run_task.assert_called_once()
+    call_args = mock_run_task.call_args[0][0]
+    assert call_args['context_id'] == 'stream-context-123'
+    assert 'history_length' in call_args
+    assert call_args['history_length'] == 15

--- a/uv.lock
+++ b/uv.lock
@@ -467,6 +467,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 docs = [
@@ -497,6 +498,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 docs = [
@@ -1392,6 +1394,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241, upload-time = "2025-05-26T13:58:45.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923, upload-time = "2025-05-26T13:58:43.487Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "backrefs"
 version = "5.9"
 source = { registry = "https://pypi.org/simple" }
@@ -439,6 +448,7 @@ dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "opentelemetry-api" },
     { name = "pydantic" },
+    { name = "sse-starlette" },
     { name = "starlette" },
 ]
 
@@ -452,9 +462,11 @@ dev = [
     { name = "asgi-lifespan" },
     { name = "coverage" },
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "inline-snapshot" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 docs = [
@@ -470,6 +482,7 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=2.3" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "pydantic", specifier = ">=2.10" },
+    { name = "sse-starlette", specifier = ">=2.0.0" },
     { name = "starlette", specifier = ">0.29.0" },
 ]
 provides-extras = ["logfire"]
@@ -479,9 +492,11 @@ dev = [
     { name = "asgi-lifespan" },
     { name = "coverage" },
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "inline-snapshot" },
     { name = "pyright" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 docs = [
@@ -562,6 +577,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/fa/66bd985dd0b7c109a3bcb89272ee0bfb7e2b4d06309ad7b38ff866734b2a/httpx_sse-0.4.1.tar.gz", hash = "sha256:8f44d34414bc7b21bf3602713005c5df4917884f76072479b21f68befa4ea26e", size = 12998, upload-time = "2025-06-24T13:21:05.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/0a/6269e3473b09aed2dab8aa1a600c70f31f00ae1349bee30658f7e358a159/httpx_sse-0.4.1-py3-none-any.whl", hash = "sha256:cba42174344c3a5b06f255ce65b350880f962d99ead85e776f23c6618a377a37", size = 8054, upload-time = "2025-06-24T13:21:04.772Z" },
 ]
 
 [[package]]
@@ -1357,6 +1381,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/51/f8794af39eeb870e87a8c8068642fc07bce0c854d6865d7dd0f2a9d338c2/pytest_asyncio-1.1.0.tar.gz", hash = "sha256:796aa822981e01b68c12e4827b8697108f7205020f24b5793b3c41555dab68ea", size = 46652, upload-time = "2025-07-16T04:29:26.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/9d/bf86eddabf8c6c9cb1ea9a869d6873b46f105a5d292d3a6f7071f5b07935/pytest_asyncio-1.1.0-py3-none-any.whl", hash = "sha256:5fe2d69607b0bd75c656d1211f969cadba035030156745ee09e7d71740e58ecf", size = 15157, upload-time = "2025-07-16T04:29:24.929Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1512,6 +1550,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/f4/4a80cd6ef364b2e8b65b15816a843c0980f7a5a2b4dc701fc574952aa19f/soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a", size = 103418, upload-time = "2025-04-20T18:50:08.518Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/9c/0e6afc12c269578be5c0c1c9f4b49a8d32770a080260c333ac04cc1c832d/soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4", size = 36677, upload-time = "2025-04-20T18:50:07.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/3e/eae74d8d33e3262bae0a7e023bb43d8bdd27980aa3557333f4632611151f/sse_starlette-2.4.1.tar.gz", hash = "sha256:7c8a800a1ca343e9165fc06bbda45c78e4c6166320707ae30b416c42da070926", size = 18635, upload-time = "2025-07-06T09:41:33.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/f1/6c7eaa8187ba789a6dd6d74430307478d2a91c23a5452ab339b6fbe15a08/sse_starlette-2.4.1-py3-none-any.whl", hash = "sha256:08b77ea898ab1a13a428b2b6f73cfe6d0e607a7b4e15b9bb23e4a37b087fd39a", size = 10824, upload-time = "2025-07-06T09:41:32.321Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR implements streaming support for FastA2A using Server-Sent Events (SSE), adding support for the message/stream endpoint.

I plan on following this up with a PR targeting pydantic-ai, which will use this support to add message/stream support for pydantic-ai's `Agent.to_a2a2()` method.

  Core Implementation:
  - Added streaming infrastructure to broker layer with pub/sub pattern for event distribution
  - Implemented message/stream endpoint in applications layer
  - Extended task manager with stream_message() method that yields events as they occur
  - Updated agent card to report streaming capability when enabled

  Dependencies:
  - Added sse-starlette>=2.0.0 for SSE response handling
  - Added httpx-sse for test client support

  Configuration:
  - Added optional streaming parameter to FastA2A constructor (defaults to False)
  - Streaming is backwards compatible - existing functionality unchanged when disabled

  Testing:
  - Added comprehensive test coverage: 32 tests total with 90.18% coverage
  - Tests cover broker pub/sub, streaming endpoints, task manager, and agent capabilities

The implementation follows the A2A protocol v0.2.5 specification for streaming responses. Workers can emit real-time status updates and artifact chunks during task execution using the broker's
  send_stream_event() method.
