### PR TITLE
fix: compose a custom lifespan with the default one

### DIFF
--- a/fasta2a/applications.py
+++ b/fasta2a/applications.py
@@ -53,15 +53,12 @@ class FastA2A(Starlette):
         exception_handlers: dict[Any, ExceptionHandler] | None = None,
         lifespan: Lifespan[FastA2A] | None = None,
     ):
-        if lifespan is None:
-            lifespan = _default_lifespan
-
         super().__init__(
             debug=debug,
             routes=routes,
             middleware=middleware,
             exception_handlers=exception_handlers,
-            lifespan=lifespan,
+            lifespan=_compose_lifespan(lifespan),
         )
 
         self.name = name or 'My Agent'
@@ -174,3 +171,21 @@ class FastA2A(Starlette):
 async def _default_lifespan(app: FastA2A) -> AsyncIterator[None]:
     async with app.task_manager:
         yield
+
+
+def _compose_lifespan(lifespan: Lifespan[FastA2A] | None) -> Lifespan[FastA2A]:
+    """Wrap a user-provided lifespan inside the default one.
+
+    The default lifespan enters the task manager (and therefore the broker), which is
+    required for the application to work, so it must run even when a custom lifespan
+    is supplied.
+    """
+    if lifespan is None:
+        return _default_lifespan
+
+    @asynccontextmanager
+    async def composed_lifespan(app: FastA2A) -> AsyncIterator[None]:
+        async with _default_lifespan(app), lifespan(app):
+            yield
+
+    return composed_lifespan

--- a/fasta2a/task_manager.py
+++ b/fasta2a/task_manager.py
@@ -106,8 +106,15 @@ class TaskManager:
     storage: Storage[Any]
 
     _aexit_stack: AsyncExitStack | None = field(default=None, init=False)
+    _depth: int = field(default=0, init=False)
 
     async def __aenter__(self):
+        # Entering an already-running task manager is a no-op, so that a lifespan which
+        # enters it explicitly can be nested inside the application's default lifespan.
+        self._depth += 1
+        if self._aexit_stack is not None:
+            return self
+
         self._aexit_stack = AsyncExitStack()
         await self._aexit_stack.__aenter__()
         await self._aexit_stack.enter_async_context(self.broker)
@@ -121,6 +128,9 @@ class TaskManager:
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any):
         if self._aexit_stack is None:
             raise RuntimeError('TaskManager was not properly initialized.')
+        self._depth -= 1
+        if self._depth > 0:
+            return
         await self._aexit_stack.__aexit__(exc_type, exc_value, traceback)
         self._aexit_stack = None
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -51,6 +51,38 @@ async def test_agent_card():
         )
 
 
+async def test_custom_lifespan_still_starts_task_manager():
+    """A user-provided lifespan must not replace the default one. See #37."""
+    called = False
+
+    @asynccontextmanager
+    async def user_lifespan(app: FastA2A):
+        nonlocal called
+        called = True
+        assert app.task_manager.is_running
+        yield
+
+    app = FastA2A(storage=InMemoryStorage(), broker=InMemoryBroker(), lifespan=user_lifespan)
+    async with create_test_client(app):
+        assert app.task_manager.is_running
+    assert called
+    assert not app.task_manager.is_running
+
+
+async def test_custom_lifespan_entering_task_manager_itself():
+    """A lifespan that enters the task manager explicitly keeps working."""
+
+    @asynccontextmanager
+    async def user_lifespan(app: FastA2A):
+        async with app.task_manager:
+            yield
+
+    app = FastA2A(storage=InMemoryStorage(), broker=InMemoryBroker(), lifespan=user_lifespan)
+    async with create_test_client(app):
+        assert app.task_manager.is_running
+    assert not app.task_manager.is_running
+
+
 class TestDocsEndpoint:
     async def test_docs_endpoint_default(self):
         app = FastA2A(storage=InMemoryStorage(), broker=InMemoryBroker())


### PR DESCRIPTION
Closes #37

Passing `lifespan=` to `FastA2A` replaced the default lifespan entirely, so the task manager (and therefore the broker) was never entered — the app then failed at runtime unless the user re-implemented that setup themselves.

The user lifespan is now nested inside the default one. `TaskManager` was made re-entrant so lifespans that already enter it explicitly (the previously documented workaround, and what `tests/test_streaming.py` does) keep working unchanged.
